### PR TITLE
remove `python_version` from setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,6 @@ python_requires = >=3.7
 install_requires =
     numpy
     pint
-    python_version >= "3.7"
 
 [options.packages.find]
 where = .


### PR DESCRIPTION
Fixes #50

<!--
Thank you for your pull request.
We kindly ask you link an issue number after "Fixes #" and briefly summarize your contributions and notes.
-->

Fixes #50

Highlights:
- removed python_version pkg
-
-

Notes (if applicable):
- I don't believe we need this 
-
