### PR TITLE
Wkchuang/issue82

### DIFF
--- a/particula/__init__.py
+++ b/particula/__init__.py
@@ -1,4 +1,4 @@
-""" a simple, fast, and powerful particle simulator.
+""" A simple, fast, and powerful particle simulator.
 
     particula is a simple, fast, and powerful particle simulator,
     or at least two of the three, we hope. It is a simple particle
@@ -18,5 +18,12 @@ from pint import UnitRegistry
 
 # u is the unit registry name.
 u = UnitRegistry()
+
+# Temperature has the quirky issue that mathematical operations on temperature
+# are problematic. e.g. 298.15K + 273.15K != 25C + 0C.
+# The following setting converts all offset units to base units prior to
+# any operations.
+# https://pint.readthedocs.io/en/latest/nonmult.html
+u.autoconvert_offset_to_baseunit = True
 
 __version__ = '0.0.4'

--- a/particula/aerosol_dynamics/environment.py
+++ b/particula/aerosol_dynamics/environment.py
@@ -1,4 +1,4 @@
-"""environment class
+"""Environment class
 """
 
 import numpy as np
@@ -12,12 +12,13 @@ class Environment:
     with properties such as temperature and pressure
     and derived properties such as air viscosity.
     """
+    @u.wraps(None, [None, u.degK, u.Pa])
     def __init__(self, temperature, pressure):
         """Function calls for enviornment class."""
         self._temperature = temperature
         self._pressure = pressure
 
-    @u.wraps(u.K, [None])
+    @u.wraps(u.degK, [None])
     def temperature(self) -> float:
         """Returns the temperature of the environment."""
         return self._temperature
@@ -35,8 +36,8 @@ class Environment:
         Sutherland Viscosity Law.
         """
         mu_ref = 1.716e-5 * u.Pa * u.s  # Viscosity at T_REF
-        t_ref = 273.15 * u.K
-        suth_const = 110.4 * u.K  # Sutherland constant
+        t_ref = 273.15 * u.degK
+        suth_const = 110.4 * u.degK  # Sutherland constant
 
         return (
             mu_ref *

--- a/particula/aerosol_dynamics/particle.py
+++ b/particula/aerosol_dynamics/particle.py
@@ -1,4 +1,4 @@
-""" to instantiate particles and calculate their properties.
+""" To instantiate particles and calculate their properties.
 
     This module contains the Particle class, which is used to
     instantiate the particles and calculate their properties.
@@ -47,6 +47,7 @@ class Particle:
         mass    (float) [kg]
     """
 
+    @u.wraps(None, [None, None, u.m, u.kg / u.m**3, None])
     def __init__(self, name: str, radius, density, charge):
         """Constructs particle objects.
 

--- a/particula/aerosol_dynamics/tests/environment_test.py
+++ b/particula/aerosol_dynamics/tests/environment_test.py
@@ -1,4 +1,4 @@
-"""tests for the environment module.
+"""Tests for the environment module.
 """
 
 import pytest
@@ -6,8 +6,8 @@ from particula import u
 from particula.aerosol_dynamics import environment
 
 standard_environment = environment.Environment(
-    temperature=298,  # * u.K,
-    pressure=101325,  # * u.Pa,
+    temperature=298 * u.degK,
+    pressure=101325 * u.Pa,
 )
 
 
@@ -15,7 +15,7 @@ def test_getters():
     """
     Tests the getters for the Environment class.
     """
-    assert standard_environment.temperature() == 298 * u.K
+    assert standard_environment.temperature() == 298 * u.degK
     assert standard_environment.pressure() == 101325 * u.Pa
 
 

--- a/particula/aerosol_dynamics/tests/parcel_test.py
+++ b/particula/aerosol_dynamics/tests/parcel_test.py
@@ -1,4 +1,4 @@
-"""tests for the parcel module.
+"""Tests for the parcel module.
 """
 
 from particula import u
@@ -6,15 +6,15 @@ from particula.aerosol_dynamics import environment, parcel, particle
 
 small_particle = particle.Particle(
     name="small_particle",
-    radius=1.0e-9,
-    density=1.0,
+    radius=1.0e-9 * u.m,
+    density=1.0 * u.kg / u.m**3,
     charge=1,
 )
 
 large_particle = particle.Particle(
     name="large_particle",
-    radius=1.0e-7,
-    density=1.8,
+    radius=1.0e-7 * u.m,
+    density=1.8 * u.kg / u.m**3,
     charge=1,
 )
 

--- a/particula/aerosol_dynamics/tests/particle_test.py
+++ b/particula/aerosol_dynamics/tests/particle_test.py
@@ -146,7 +146,7 @@ def test_dimensioned_coagulation_kernel():
 
     assert small_particle.dimensioned_coagulation_kernel(
         large_particle, standard_environment
-    ) == pytest.approx(2.738e-10 * u.m**3 / u.s, rel=10)
+    ) == pytest.approx(2.738e-10, rel=10)
     assert small_particle.dimensioned_coagulation_kernel(
         large_particle, standard_environment
     ).check("[length]**3/[time]")
@@ -163,7 +163,7 @@ def test_dimensioned_coagulation_kernel():
 
     assert negative_ion.dimensioned_coagulation_kernel(
         positive_particle, standard_environment_ip
-    ) == pytest.approx(1e-12 * u.m**3 / u.s, rel=10)
+    ) == pytest.approx(1e-12, rel=10)
     # rel=10 means an order of magnitude
     assert negative_ion.dimensioned_coagulation_kernel(
         positive_particle, standard_environment_ip

--- a/particula/aerosol_dynamics/tests/particle_test.py
+++ b/particula/aerosol_dynamics/tests/particle_test.py
@@ -2,7 +2,6 @@
 """
 
 import numpy as np
-import pint
 import pytest
 from particula import u
 from particula.aerosol_dynamics import environment, particle
@@ -19,13 +18,6 @@ large_particle = particle.Particle(
     radius=1.0e-7 * u.m,
     density=1.8 * u.kg / u.m**3,  # need fixing, add e3
     charge=1,
-)
-
-invalid_particle = particle.Particle(
-    name="invalid_particle",
-    radius=1.0e-7 * u.lb,
-    density=1 * u.kg / u.m**3,
-    charge=3 * u.C,
 )
 
 standard_environment = environment.Environment(
@@ -48,7 +40,7 @@ positive_particle = particle.Particle(
 )
 
 standard_environment_ip = environment.Environment(
-    temperature=300 * u.K,
+    temperature=300 * u.degK,
     pressure=101325 * u.Pa,
 )
 
@@ -80,16 +72,6 @@ def test_knudsen_number():
     assert large_particle.knudsen_number(
         standard_environment
     ) == pytest.approx(0.6644, rel=1e-3)
-    with pytest.raises(pint.errors.DimensionalityError):
-        assert invalid_particle.knudsen_number(
-            standard_environment
-        ) == pytest.approx(0.65)
-        assert invalid_particle.knudsen_number(
-            standard_environment
-        ).check("[None]")
-    # with pytest.raises(AssertionError):
-    #     assert invalid_particle.knudsen_number() == pytest.approx(0.65)
-    #     assert invalid_particle.knudsen_number().check("[None]")
 
 
 def test_slip_correction_factor():


### PR DESCRIPTION
<!--
Thank you for your pull request.
We kindly ask you link an issue number after "Fixes #" and briefly summarize your contributions and notes.
-->

Fixes #82

Highlights:
- Classes will now check inputs for the correct units.
- Temperature inputs will automatically be converted to base units (Kelvin) prior to any mathematical operations. 

Notes (if applicable):
- A UnitStrippedWarning pops up when running `particle_test`. Need help diagnosing the issue.
-
