### PR TITLE
correctly set branch for colab, binder, etc.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -13,7 +13,7 @@ launch_buttons:
 repository:
   url: https://github.com/uncscode/particula
   path_to_book: docs
-  branch: tags/v0.0.3
+  branch: v0.0.3
 
 html:
   use_repository_button: true

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -13,7 +13,7 @@ launch_buttons:
 repository:
   url: https://github.com/uncscode/particula
   path_to_book: docs
-  branch: main
+  branch: tags/v0.0.3
 
 html:
   use_repository_button: true


### PR DESCRIPTION
Fixes #83 

This sets the branch to v0.0.3 (for now, but will go up later) instead of main. This way, the documentation are run for the latest release rather than main (which often contains newer additions after releases).