### PR TITLE
starting a list of spellcheck overrides in devcontainer 

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,8 @@ RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/
 RUN pip3 --disable-pip-version-check --no-cache-dir install --upgrade pip
+COPY . /workspaces/particula/
+RUN pip3 --disable-pip-version-check --no-cache-dir install -e "/workspaces/particula/[dev]"
 
 # [Optional] Uncomment this section to install additional OS packages.
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -84,7 +84,7 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "pip3 install --user -r requirements.txt",
 	"postCreateCommand": "pip3 install --prefix=~/.local -e '.[dev]'",
-    // can add container envs here like dask later
+	// can add container envs here like dask later
 
 	// "containerEnv": {
 	// }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -83,7 +83,7 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "pip3 install --user -r requirements.txt",
-	"postCreateCommand": "pip3 install --prefix=~/.local -e '.[dev]'",
+	// "postCreateCommand": "pip3 install --prefix=~/.local -e '.[dev]'",
 	// can add container envs here like dask later
 
 	// "containerEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,17 +31,18 @@
 		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
 		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
 		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
-        "breadcrumbs.enabled": true,
-        "editor.stablePeek": true,
+		"breadcrumbs.enabled": true,
+		"editor.stablePeek": true,
 		// "editor.tabSize": 2, // Add this to override the default of 4.
 		// "editor.detectIndentation": false, // Add this to disable automatic indentation detection.
-        "editor.bracketPairColorization.enabled": true,
-        "editor.lightbulb.enable": true,
-        "python.defaultInterpreterPath": "/usr/local/bin/python",
-        "cSpell.words": [
-            "particula",
-            "conda",
-        ]
+		"editor.bracketPairColorization.enabled": true,
+		"editor.lightbulb.enable": true,
+		"python.defaultInterpreterPath": "/usr/local/bin/python",
+		// add to list any words you want ignored when spellchecking
+		"cSpell.words": [
+			"particula",
+			"conda",
+		]
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
@@ -82,8 +83,7 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "pip3 install --user -r requirements.txt",
-    "postCreateCommand": "pip3 install --prefix=~/.local -e '.[dev]'",
-
+		"postCreateCommand": "pip3 install --prefix=~/.local -e '.[dev]'",
     // can add container envs here like dask later
 
 	// "containerEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -37,7 +37,11 @@
 		// "editor.detectIndentation": false, // Add this to disable automatic indentation detection.
         "editor.bracketPairColorization.enabled": true,
         "editor.lightbulb.enable": true,
-        "python.defaultInterpreterPath": "/usr/local/bin/python"
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "cSpell.words": [
+            "particula",
+            "conda",
+        ]
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
@@ -70,7 +74,7 @@
 		"msrvida.vscode-sanddance",
 		"analytic-signal.preview-pdf",
 		"eamodio.gitlens",
-		"ms-vsliveshare.vsliveshare-pack"
+		"ms-vsliveshare.vsliveshare-pack",
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -74,7 +74,7 @@
 		"msrvida.vscode-sanddance",
 		"analytic-signal.preview-pdf",
 		"eamodio.gitlens",
-		"ms-vsliveshare.vsliveshare-pack",
+		"ms-vsliveshare.vsliveshare-pack"
 	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -83,7 +83,7 @@
 
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "pip3 install --user -r requirements.txt",
-		"postCreateCommand": "pip3 install --prefix=~/.local -e '.[dev]'",
+	"postCreateCommand": "pip3 install --prefix=~/.local -e '.[dev]'",
     // can add container envs here like dask later
 
 	// "containerEnv": {

--- a/particula/__init__.py
+++ b/particula/__init__.py
@@ -19,4 +19,4 @@ from pint import UnitRegistry
 # u is the unit registry name.
 u = UnitRegistry()
 
-__version__ = '0.0.4.dev0'
+__version__ = "0.0.4.dev0"


### PR DESCRIPTION
- This is a simple addition to the devcontainer to override the spellcheck. Usually I would add these types of spell checks override to my personal user account, but I thought sharing them here may make using the docker container more useful/easier. Please feel free to add more to this list as you wish.
- Also decided to move `pip install -e .[dev]` to the Dockerfile because that way it won't happen every single time upon reopening the container