### PR TITLE
improve coag gain calculation

### DIFF
--- a/particula/__init__.py
+++ b/particula/__init__.py
@@ -19,4 +19,4 @@ from pint import UnitRegistry
 # u is the unit registry name.
 u = UnitRegistry()
 
-__version__ = "0.0.4.dev1"
+__version__ = "0.0.4.dev2"

--- a/particula/util/coagulation_rate.py
+++ b/particula/util/coagulation_rate.py
@@ -104,7 +104,7 @@ class CoagulationRate:
         for i, dpa in enumerate(rads):
 
             # make the dummy radius for integration
-            dpd = np.linspace(0, dpa/2**(1/3), rads.m.size)
+            dpd = np.linspace(0, dpa.m/2**(1/3), rads.m.size)*rads.u
 
             # get the dummy radius for interpolation
             dpi = (dpa**3 - dpd**3)**(1/3)
@@ -114,13 +114,13 @@ class CoagulationRate:
             num_oth = np.interp(dpi, rads, nums)
 
             # interpolate the kernel to the dummy radius
-            ker_oth = interp.ev(dpi.m, rads.m) * kern.u
+            ker_oth = interp.ev(dpi.m, dpd.m) * kern.u
 
             # calculate last term
             dss = (dpa**3 - dpd**3)**(2/3)
 
             # calculate the gain
-            test = 0.5*(dpa**2)*np.trapz(ker_oth*num_oth*num_rep/dss, dpd)
+            test = (dpa**2)*np.trapz(ker_oth*num_oth*num_rep/dss, dpd)
 
             # store the gain
             gain[i] = test.m

--- a/particula/util/coagulation_rate.py
+++ b/particula/util/coagulation_rate.py
@@ -85,45 +85,22 @@ class CoagulationRate:
             (other_radius**3 - some_radius**3)*(1/3)
             we use interporlation techniques.
 
-            This could be made better in the future.
+            Using `RectBivariateSpline` accelerates this significantly.
         """
 
-        # get the parameters
         nums, rads, kern = self.coag_prep()
 
-        # make a sekeloton array for the gain
-        gain = np.zeros_like(rads)
-
         interp = RectBivariateSpline(
-            rads.m,
-            rads.m,
-            kern.m
+            rads.m, rads.m, kern.m * nums.m * np.transpose([nums.m])
         )
 
-        # loop over the radius of interest (rads above)
-        for i, dpa in enumerate(rads):
+        dpd = np.linspace(0, rads.m/2**(1/3), rads.m.size)*rads.u
+        dpi = (rads**3 - (np.transpose(dpd.m)*dpd.u)**3)**(1/3)
 
-            # make the dummy radius for integration
-            dpd = np.linspace(0, dpa.m/2**(1/3), rads.m.size)*rads.u
+        gain = rads**2 * np.trapz(
+            interp.ev(dpd.m, dpi.m) * kern.u * nums.u * nums.u / dpi**2,
+            dpd,
+            axis=0
+        )
 
-            # get the dummy radius for interpolation
-            dpi = (dpa**3 - dpd**3)**(1/3)
-
-            # interpolate the distribution to the dummy radii
-            num_rep = np.interp(dpd, rads, nums)
-            num_oth = np.interp(dpi, rads, nums)
-
-            # interpolate the kernel to the dummy radius
-            ker_oth = interp.ev(dpi.m, dpd.m) * kern.u
-
-            # calculate last term
-            dss = (dpa**3 - dpd**3)**(2/3)
-
-            # calculate the gain
-            test = (dpa**2)*np.trapz(ker_oth*num_oth*num_rep/dss, dpd)
-
-            # store the gain
-            gain[i] = test.m
-
-        # return it
-        return gain*test.u
+        return gain


### PR DESCRIPTION
Fixes #138 
Fixes #148 

<details>
sketchy matlab code snippet from back in the day... as a guidance to resolve the bug, I am aging and thus unable to be creative about algorithms...

```matlab

coagLossRates(11,:) = bsxfun(@times, ...
  particleNumberDistributionFractioned(11,:),...
  (1e6).*trapz(particleDiameter_nm, ...
  bsxfun(@times,coagK25at,particleNumberDistributionFractioned(1 ,:))+...
  bsxfun(@times,coagK20at,particleNumberDistributionFractioned(2 ,:))+...
  bsxfun(@times,coagK15at,particleNumberDistributionFractioned(3 ,:))+...
  bsxfun(@times,coagK10at,particleNumberDistributionFractioned(4 ,:))+...
  bsxfun(@times,coagK5at ,particleNumberDistributionFractioned(5 ,:))+...
  bsxfun(@times,coagK0   ,particleNumberDistributionFractioned(6 ,:))+...
  bsxfun(@times,coagK5re ,particleNumberDistributionFractioned(7 ,:))+...
  bsxfun(@times,coagK10re,particleNumberDistributionFractioned(8 ,:))+...
  bsxfun(@times,coagK15re,particleNumberDistributionFractioned(9 ,:))+...
  bsxfun(@times,coagK20re,particleNumberDistributionFractioned(10,:))+...
  bsxfun(@times,coagK25re,particleNumberDistributionFractioned(11,:)),2)');


% brute force calculations of the coagulation gain rate
% using a double trapz-interp2 estimation
% (very accurate but costly)
% replace interp2 by manual matrix of upper/lower bounds
% see updated file

coagGainRates = zeros(11,length(dp));


[dp1, dp2] = meshgrid(particleDiameter_nm);


coagGainRates(1,:) =  bsxfun(@times,.5.*(particleDiameter_nm.^2),(...
  trapz(particleDiameter_nm,...
    triu(interp2(dp1,dp2,(1e6).*coagK0.*...
      bsxfun(@times,particleNumberDistributionFractioned(1,:),...
        particleNumberDistributionFractioned(6,:)'),...
          dp2,(bsxfun(@minus, diag(dp2)'.^3 ,triu(dp2,1).^3)).^(1/3),  ...
'spline')./(bsxfun(@minus,diag(dp2)'.^3,triu(dp2,1).^3) ).^(2/3),1)) +...
  trapz(particleDiameter_nm,...
    triu(interp2(dp1,dp2,(1e6).*coagK5re.*...
      bsxfun(@times,particleNumberDistributionFractioned(2,:),...
        particleNumberDistributionFractioned(5,:)'),...
          dp2,(bsxfun(@minus, diag(dp2)'.^3 ,triu(dp2,1).^3)).^(1/3),  ...
'spline')./(bsxfun(@minus,diag(dp2)'.^3,triu(dp2,1).^3) ).^(2/3),1)) +...
  trapz(particleDiameter_nm,...
    triu(interp2(dp1,dp2,(1e6).*coagK6re.*...
      bsxfun(@times,particleNumberDistributionFractioned(3,:),...
        particleNumberDistributionFractioned(4,:)'),...
          dp2,(bsxfun(@minus, diag(dp2)'.^3 ,triu(dp2,1).^3)).^(1/3),  ...
'spline')./(bsxfun(@minus,diag(dp2)'.^3,triu(dp2,1).^3) ).^(2/3),1)) +...
  trapz(particleDiameter_nm,...
    triu(interp2(dp1,dp2,(1e6).*coagK6re.*...
      bsxfun(@times,particleNumberDistributionFractioned(4,:),...
        particleNumberDistributionFractioned(3,:)'),...
          dp2,(bsxfun(@minus, diag(dp2)'.^3 ,triu(dp2,1).^3)).^(1/3),  ...
'spline')./(bsxfun(@minus,diag(dp2)'.^3,triu(dp2,1).^3) ).^(2/3),1)) + ...
  trapz(particleDiameter_nm,...
    triu(interp2(dp1,dp2,(1e6).*coagK5re.*...
      bsxfun(@times,particleNumberDistributionFractioned(5,:),...
        particleNumberDistributionFractioned(2,:)'),...
          dp2,(bsxfun(@minus, diag(dp2)'.^3 ,triu(dp2,1).^3)).^(1/3),  ...
'spline')./(bsxfun(@minus,diag(dp2)'.^3,triu(dp2,1).^3) ).^(2/3),1)) +...
  trapz(particleDiameter_nm,...
    triu(interp2(dp1,dp2,(1e6).*coagK0.*...
      bsxfun(@times,particleNumberDistributionFractioned(6,:),...
        particleNumberDistributionFractioned(1,:)'),...
          dp2,(bsxfun(@minus, diag(dp2)'.^3 ,triu(dp2,1).^3)).^(1/3),  ...
'spline')./(bsxfun(@minus,diag(dp2)'.^3,triu(dp2,1).^3) ).^(2/3),1))));


```

I guess the keys are:
- need to mesh the aux dps
- need to fine-tune interp
- need to thoroughly test this on smaller cases
- ughhhhhhh
- beautiful code tho

</details>