### PR TITLE
typing is included in stdlib in 3.5+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ keywords = [
 
 dependencies = [
     "numpy", "scipy", "pint", "hypersolver==0.0.8", "pandas",
-    "netCDF4", "shapely", "PyMieScatt", "tqdm", "pytz", "typing",
+    "netCDF4", "shapely", "PyMieScatt", "tqdm", "pytz",
     "matplotlib"
 ]
 


### PR DESCRIPTION
no need to include it in the deps 
especilaly that we are only acepting 3.7 anyway

fix #370 