### PR TITLE
release v0.0.18

### DIFF
--- a/particula/__init__.py
+++ b/particula/__init__.py
@@ -20,7 +20,7 @@ from particula.logger_setup import setup
 # u is the unit registry name.
 u = UnitRegistry(force_ndarray=True)
 
-__version__ = "0.0.17.dev0"
+__version__ = "0.0.18"
 
 # setup the logger
 logger = setup()


### PR DESCRIPTION
I released v0.0.17 but forgot to change the version, so pypi release was a dev release... going ahead and releasing v0.0.18 now.

## Summary by Sourcery

Update the version number to 0.0.18 in preparation for a new release.