### PR TITLE
Test for py13

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     
-    - name: Set up Python 3.11
+    - name: Set up Python 3.12
       uses: actions/setup-python@v5.3.0
       with:
-        python-version: "3.11"
+        python-version: "3.12"
         cache: 'pip' # caching pip dependencies
         
     - name: Install dependencies

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -21,10 +21,10 @@ jobs:
           with: 
             persist-credentials: false
 
-        - name: Set up Python 3.11
+        - name: Set up Python 3.12
           uses: actions/setup-python@v5.3.0
           with:
-            python-version: '3.11'
+            python-version: '3.12'
             cache: 'pip' # caching pip dependencies
 
         - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-         python-version: ["3.9", "3.10", "3.11", "3.12"]
+         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ keywords = [
 ]
 
 dependencies = [
-    "numpy", "scipy", "pint", "hypersolver==0.0.8", "pytz"
+    "numpy", "scipy", "pint>=0.24.4", "hypersolver==0.0.8", "pytz"
 ]
 
 # This is set automatically by flit using `particula.__version__`


### PR DESCRIPTION
## Summary by Sourcery

Update CI workflows to use Python 3.12, add Python 3.13 to the test matrix, and adjust the 'pint' dependency version.

Enhancements:
- Update the dependency version for 'pint' to be at least 0.24.4 in the project configuration.

CI:
- Update CI workflows to use Python 3.12 instead of Python 3.11 for linting and documentation generation.

Tests:
- Add Python 3.13 to the testing matrix in the CI workflow.