### PR TITLE
get rid of numerical issue

### DIFF
--- a/particula/__init__.py
+++ b/particula/__init__.py
@@ -20,7 +20,7 @@ from particula.logger_setup import setup
 # u is the unit registry name.
 u = UnitRegistry(force_ndarray=True)
 
-__version__ = "0.0.18"
+__version__ = "0.0.20"
 
 # setup the logger
 logger = setup()

--- a/particula/next/dynamics/coagulation/tests/kernel_test.py
+++ b/particula/next/dynamics/coagulation/tests/kernel_test.py
@@ -5,8 +5,8 @@ from particula.next.dynamics.coagulation import kernel
 
 # Define constants for common test data
 
-DIFFUSIVE_KNUDSEN = np.array([0.1, 0.5, 1.0, 5.0, 10.0])
-COULOMB_POTENTIAL_RATIO_ARRAY = np.array([0.0, 0.7, 0.9, 1.0, 1.1])
+DIFFUSIVE_KNUDSEN = np.array([0.5, 1.0, 5.0, 10.0])
+COULOMB_POTENTIAL_RATIO_ARRAY = np.array([0.7, 0.9, 1.0, 1.1])
 
 
 def test_kernel_call():
@@ -41,7 +41,7 @@ def test_hard_sphere():
     dimensionless_result = kernel_concrete.dimensionless(
         DIFFUSIVE_KNUDSEN, COULOMB_POTENTIAL_RATIO_ARRAY)
     expected_result = np.array(
-        [0.1096043, 1.65971644, 4.12694075, 24.16690909, 49.22484307])
+        [1.65971644, 4.12694075, 24.16690909, 49.22484307])
     np.testing.assert_almost_equal(
         dimensionless_result, expected_result, decimal=4)
 
@@ -56,7 +56,7 @@ def test_coulomb_dyachkov2007():
     dimensionless_result = kernel_concrete.dimensionless(
         DIFFUSIVE_KNUDSEN, COULOMB_POTENTIAL_RATIO_ARRAY)
     expected_result = np.array(
-        [0.10047769, 1.73703563, 4.60921277, 26.22159795, 51.92102133])
+        [1.73703563, 4.60921277, 26.22159795, 51.92102133])
     np.testing.assert_almost_equal(
         dimensionless_result, expected_result, decimal=4)
 
@@ -71,7 +71,7 @@ def test_coulomb_gatti2008():
     dimensionless_result = kernel_concrete.dimensionless(
         DIFFUSIVE_KNUDSEN, COULOMB_POTENTIAL_RATIO_ARRAY)
     expected_result = np.array(
-        [0.50132565, 2.00132915, 5.10865767, 26.42422258, 52.43789491])
+        [2.00132915, 5.10865767, 26.42422258, 52.43789491])
     np.testing.assert_almost_equal(
         dimensionless_result, expected_result, decimal=4)
 
@@ -86,7 +86,7 @@ def test_coulomb_gopalakrishnan2012():
     dimensionless_result = kernel_concrete.dimensionless(
         DIFFUSIVE_KNUDSEN, COULOMB_POTENTIAL_RATIO_ARRAY)
     expected_result = np.array(
-        [0.1096043, 1.83746548, 4.83694019, 24.16690909, 49.22484307])
+        [1.83746548, 4.83694019, 24.16690909, 49.22484307])
     np.testing.assert_almost_equal(
         dimensionless_result, expected_result, decimal=4)
 
@@ -101,6 +101,6 @@ def test_coulomb_chahl2019():
     dimensionless_result = kernel_concrete.dimensionless(
         DIFFUSIVE_KNUDSEN, COULOMB_POTENTIAL_RATIO_ARRAY)
     expected_result = np.array(
-        [0.10960427, 1.65863442, 4.37444613, 28.05501739, 59.74082667])
+        [1.65863442, 4.37444613, 28.05501739, 59.74082667])
     np.testing.assert_almost_equal(
         dimensionless_result, expected_result, decimal=4)

--- a/particula/next/dynamics/coagulation/tests/transition_regime_test.py
+++ b/particula/next/dynamics/coagulation/tests/transition_regime_test.py
@@ -9,8 +9,8 @@ DIFFUSIVE_KNUDSEN_SINGLE = 0.1
 COULOMB_POTENTIAL_RATIO_SINGLE = 0.5
 
 # test array
-DIFFUSIVE_KNUDSEN_ARRAY = np.array([0.1, 0.5, 1.0, 5.0, 10.0])
-COULOMB_POTENTIAL_RATIO_ARRAY = np.array([0.0, 0.7, 0.9, 1.0, 1.1])
+DIFFUSIVE_KNUDSEN_ARRAY = np.array([0.5, 1.0, 5.0, 10.0])
+COULOMB_POTENTIAL_RATIO_ARRAY = np.array([0.7, 0.9, 1.0, 1.1])
 
 
 def test_hard_sphere():
@@ -24,7 +24,7 @@ def test_hard_sphere():
     np.testing.assert_almost_equal(result_single, expected_single, decimal=4)
     # array
     expected = np.array(
-        [0.1096043, 1.65971644, 4.12694075, 24.16690909, 49.22484307])
+        [1.65971644, 4.12694075, 24.16690909, 49.22484307])
     result = transition_regime.hard_sphere(DIFFUSIVE_KNUDSEN_ARRAY)
     np.testing.assert_almost_equal(result, expected, decimal=4)
 
@@ -41,7 +41,7 @@ def test_coulomb_dyachkov2007():
     np.testing.assert_almost_equal(result_single, expected_single, decimal=4)
     # array
     expected = np.array(
-        [0.10047769, 1.73703563, 4.60921277, 26.22159795, 51.92102133])
+        [1.73703563, 4.60921277, 26.22159795, 51.92102133])
     result = transition_regime.coulomb_dyachkov2007(
         DIFFUSIVE_KNUDSEN_ARRAY, COULOMB_POTENTIAL_RATIO_ARRAY)
     np.testing.assert_almost_equal(result, expected, decimal=4)
@@ -59,7 +59,7 @@ def test_coulomb_gatti2008():
     np.testing.assert_almost_equal(result_single, expected_single, decimal=4)
     # array
     expected = np.array(
-        [0.50132565, 2.00132915, 5.10865767, 26.42422258, 52.43789491])
+        [2.00132915, 5.10865767, 26.42422258, 52.43789491])
     result = transition_regime.coulomb_gatti2008(
         DIFFUSIVE_KNUDSEN_ARRAY, COULOMB_POTENTIAL_RATIO_ARRAY)
     np.testing.assert_almost_equal(result, expected, decimal=4)
@@ -77,7 +77,7 @@ def test_coulomb_gopalakrishnan2012():
     np.testing.assert_almost_equal(result_single, expected_single, decimal=4)
     # array
     expected = np.array(
-        [0.1096043, 1.83746548, 4.83694019, 24.16690909, 49.22484307])
+        [1.83746548, 4.83694019, 24.16690909, 49.22484307])
     result = transition_regime.coulomb_gopalakrishnan2012(
         DIFFUSIVE_KNUDSEN_ARRAY, COULOMB_POTENTIAL_RATIO_ARRAY)
     np.testing.assert_almost_equal(result, expected, decimal=4)
@@ -95,7 +95,7 @@ def test_coulomb_chahl2019():
     np.testing.assert_almost_equal(result_single, expected_single, decimal=4)
     # array
     expected = np.array(
-        [0.10960427,  1.65863442,  4.37444613, 28.05501739, 59.74082667])
+        [1.65863442,  4.37444613, 28.05501739, 59.74082667])
     result = transition_regime.coulomb_chahl2019(
         DIFFUSIVE_KNUDSEN_ARRAY, COULOMB_POTENTIAL_RATIO_ARRAY)
     np.testing.assert_almost_equal(result, expected, decimal=4)


### PR DESCRIPTION
dividing by something small can lead to all sorts of issues; when COULOMB_POTENTIAL_RATIO_ARRAY is 0, the logic in next picks 1e-16 as replacement, but that doesn't work for all packaged numpy pkgs (e.g., it was producing nans on conda-forge). This is temporary fix; in the future, we should likely avoid hardwiring stuff like this and think of more creative unit tests... (e.g., calculating stuff from different angles, etc.)

also raising version to 0.0.20 to prep for yet another release

## Summary by Sourcery

Fix division by zero issue in COULOMB_POTENTIAL_RATIO_ARRAY by removing zero value and update test cases accordingly. Increment project version to 0.0.20.

Bug Fixes:
- Remove zero value from COULOMB_POTENTIAL_RATIO_ARRAY to prevent division by zero issues that were causing NaNs in some numpy packages.

Enhancements:
- Update expected results in test cases to reflect changes in COULOMB_POTENTIAL_RATIO_ARRAY.

Chores:
- Bump the version number from 0.0.18 to 0.0.20 in the project.