### PR TITLE
add merge group option

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  merge_group:
+    branches: [ main ]
 
 jobs:
   linting:

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -9,6 +9,8 @@ on:
       - main
     paths:
       - 'docs/**'
+  merge_group:
+    branches: [ main ]
 
 jobs:
   blds:

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -5,6 +5,8 @@ on:
     types: [published]
   pull_request:
     branches: [ main ]
+  merge_group:
+    branches: [ main ]
 
 jobs:
   pyping:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  merge_group:
+    branches: [ main ]
 
 jobs:
   testing:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Add 'merge_group' option to GitHub Actions workflows for linting, documentation, PyPI, and testing.