### PR TITLE
Document Builder ABC

### DIFF
--- a/particula/abc_builder.py
+++ b/particula/abc_builder.py
@@ -1,14 +1,4 @@
 """Abstract Base Class for Builder classes.
-
-This module also defines mixin classes for the Builder classes to set
-some optional method to be used in the Builder classes.
-https://en.wikipedia.org/wiki/Mixin
-
-Mixins are used to set the common parameters of the Surface strategies.
-
-We use explicit initialization of the mixins in the __init__ method, for
-clarity and traceability steps. Using super() would be more concise, but
-it would be harder to trace the inheritance chain.
 """
 
 # pylint: disable=too-few-public-methods
@@ -37,14 +27,12 @@ class BuilderABC(ABC):
         - build (abstract): Build and return the strategy object.
 
     Raises:
-        - ValueError: If any required key is missing during check_keys or
+        - ValueError : If any required key is missing during check_keys or
             pre_build_check, or if trying to set an invalid parameter.
-        - Warning: If using default units for any parameter.
+        - Warning : If using default units for any parameter.
 
     References:
-        This module also defines mixin classes for the Builder classes to set
-        some optional method to be used in the Builder classes.
-        [Mixin Wikipedia](https://en.wikipedia.org/wiki/Mixin)
+        - Builder Pattern : https://refactoring.guru/design-patterns/builder
     """
 
     def __init__(self, required_parameters: Optional[list[str]] = None):

--- a/particula/abc_builder.py
+++ b/particula/abc_builder.py
@@ -51,6 +51,15 @@ class BuilderABC(ABC):
         Raises:
             - ValueError: If any required key is missing or if trying to set an
                 invalid parameter.
+
+        Example:
+            ``` py
+            builder = Builder()
+            builder.check_keys({
+                "parameter1": 1,
+                "parameter2": 2,
+            })
+            ```
         """
 
         # Check if all required keys are present
@@ -92,6 +101,15 @@ class BuilderABC(ABC):
         Raises:
             - ValueError : If any required key is missing.
             - Warning : If using default units for any parameter.
+
+        Example:
+            ``` py
+            builder = Builder().set_parameters({
+                "parameter1": 1,
+                "parameter2": 2,
+                "parameter2_units": "K",
+            })
+            ```
         """
         self.check_keys(parameters)
         for key in self.required_parameters:
@@ -112,6 +130,12 @@ class BuilderABC(ABC):
 
             Raises:
                 - ValueError : If any required parameter is missing.
+
+            Example:
+                ``` py
+                builder = Builder()
+                builder.pre_build_check()
+                ```
         """
         if missing := [
             p for p in self.required_parameters if getattr(self, p) is None
@@ -128,4 +152,10 @@ class BuilderABC(ABC):
 
         Returns:
             - strategy : The built strategy object.
+
+        Example:
+            ``` py
+            builder = Builder()
+            strategy = builder.build()
+            ```
         """

--- a/particula/abc_builder.py
+++ b/particula/abc_builder.py
@@ -40,8 +40,8 @@ class BuilderABC(ABC):
             - parameters : The parameters dictionary to check.
 
         Raises:
-            - ValueError : If any required key is missing or if trying to set an
-                invalid parameter.
+            - ValueError : If any required key is missing or if trying to set
+                an invalid parameter.
 
         Example:
             ``` py

--- a/particula/abc_builder.py
+++ b/particula/abc_builder.py
@@ -1,4 +1,8 @@
 """Abstract Base Class for Builder classes.
+
+References:
+    - Builder Pattern : https://refactoring.guru/design-patterns/builder
+
 """
 
 # pylint: disable=too-few-public-methods

--- a/particula/abc_builder.py
+++ b/particula/abc_builder.py
@@ -24,22 +24,22 @@ class BuilderABC(ABC):
     """Abstract base class for builders with common methods to check keys and
     set parameters from a dictionary.
 
-    Attributes:
-        required_parameters: List of required parameters for the builder.
+    Args:
+        - required_parameters: List of required parameters for the builder.
 
     Methods:
-        check_keys (parameters): Check if the keys you want to set are
-        present in the parameters dictionary.
-        set_parameters (parameters): Set parameters from a dictionary including
-        optional suffix for units as '_units'.
-        pre_build_check(): Check if all required attribute parameters are set
-        before building.
-        build (abstract): Build and return the strategy object.
+        - check_keys (parameters): Check if the keys you want to set are
+        - present in the parameters dictionary.
+        - set_parameters (parameters): Set parameters from a dictionary
+            including optional suffix for units as '_units'.
+        - pre_build_check(): Check if all required attribute parameters are set
+            before building.
+        - build (abstract): Build and return the strategy object.
 
     Raises:
-        ValueError: If any required key is missing during check_keys or
-        pre_build_check, or if trying to set an invalid parameter.
-        Warning: If using default units for any parameter.
+        - ValueError: If any required key is missing during check_keys or
+            pre_build_check, or if trying to set an invalid parameter.
+        - Warning: If using default units for any parameter.
 
     References:
         This module also defines mixin classes for the Builder classes to set
@@ -54,11 +54,11 @@ class BuilderABC(ABC):
         """Check if the keys are present and valid.
 
         Args:
-            parameters: The parameters dictionary to check.
+            - parameters: The parameters dictionary to check.
 
         Raises:
-            ValueError: If any required key is missing or if trying to set an
-            invalid parameter.
+            - ValueError: If any required key is missing or if trying to set an
+                invalid parameter.
         """
 
         # Check if all required keys are present
@@ -92,14 +92,14 @@ class BuilderABC(ABC):
         units as '_units'.
 
         Args:
-            parameters: The parameters dictionary to set.
+            - parameters : The parameters dictionary to set.
 
         Returns:
-            self: The builder object with the set parameters.
+            - The builder object with the set parameters.
 
         Raises:
-            ValueError: If any required key is missing.
-            Warning: If using default units for any parameter.
+            - ValueError : If any required key is missing.
+            - Warning : If using default units for any parameter.
         """
         self.check_keys(parameters)
         for key in self.required_parameters:
@@ -118,8 +118,8 @@ class BuilderABC(ABC):
     def pre_build_check(self):
         """Check if all required attribute parameters are set before building.
 
-        Raises:
-            ValueError: If any required parameter is missing.
+            Raises:
+                - ValueError : If any required parameter is missing.
         """
         if missing := [
             p for p in self.required_parameters if getattr(self, p) is None
@@ -135,5 +135,5 @@ class BuilderABC(ABC):
         """Build and return the strategy object with the set parameters.
 
         Returns:
-            strategy: The built strategy object.
+            - strategy : The built strategy object.
         """

--- a/particula/abc_builder.py
+++ b/particula/abc_builder.py
@@ -21,15 +21,6 @@ class BuilderABC(ABC):
     Args:
         - required_parameters: List of required parameters for the builder.
 
-    Methods:
-        - check_keys (parameters): Check if the keys you want to set are
-        - present in the parameters dictionary.
-        - set_parameters (parameters): Set parameters from a dictionary
-            including optional suffix for units as '_units'.
-        - pre_build_check(): Check if all required attribute parameters are set
-            before building.
-        - build (abstract): Build and return the strategy object.
-
     Raises:
         - ValueError : If any required key is missing during check_keys or
             pre_build_check, or if trying to set an invalid parameter.
@@ -46,10 +37,10 @@ class BuilderABC(ABC):
         """Check if the keys are present and valid.
 
         Args:
-            - parameters: The parameters dictionary to check.
+            - parameters : The parameters dictionary to check.
 
         Raises:
-            - ValueError: If any required key is missing or if trying to set an
+            - ValueError : If any required key is missing or if trying to set an
                 invalid parameter.
 
         Example:

--- a/particula/gas/vapor_pressure_builders.py
+++ b/particula/gas/vapor_pressure_builders.py
@@ -23,14 +23,13 @@ class AntoineBuilder(BuilderABC):
     - Units: 'a_units' = None, 'b_units' = 'K', 'c_units' = 'K'
 
     Methods:
-    --------
-    - set_a(a, a_units): Set the coefficient 'a' of the Antoine equation.
-    - set_b(b, b_units): Set the coefficient 'b' of the Antoine equation.
-    - set_c(c, c_units): Set the coefficient 'c' of the Antoine equation.
-    - set_parameters(params): Set coefficients from a dictionary including
-        optional units.
-    - build(): Build the AntoineVaporPressureStrategy object with the set
-        coefficients.
+        - set_a(a, a_units): Set the coefficient 'a' of the Antoine equation.
+        - set_b(b, b_units): Set the coefficient 'b' of the Antoine equation.
+        - set_c(c, c_units): Set the coefficient 'c' of the Antoine equation.
+        - set_parameters(params): Set coefficients from a dictionary including
+            optional units.
+        - build(): Build the AntoineVaporPressureStrategy object with the set
+            coefficients.
     """
 
     def __init__(self):
@@ -81,22 +80,8 @@ class ClausiusClapeyronBuilder(BuilderABC):
     setting the latent heat of vaporization, initial temperature, and initial
     pressure with unit handling and then builds the strategy object.
 
-    - Equation: dP/dT = L / (R * T^2)
-    - Units: 'latent_heat_units' = 'J/kg', 'temperature_initial_units' = 'K',
-        'pressure_initial_units' = 'Pa'
-
-    Methods:
-    --------
-    - set_latent_heat(latent_heat, latent_heat_units): Set the latent heat of
-        vaporization.
-    - set_temperature_initial(temperature_initial, temperature_initial_units):
-        Set the initial temperature.
-    - set_pressure_initial(pressure_initial, pressure_initial_units): Set the
-        initial pressure.
-    - set_parameters(parameters): Set parameters from a dictionary including
-        optional units.
-    - build(): Build the ClausiusClapeyronStrategy object with the set
-        parameters.
+    References:
+        - Equation: dP/dT = L / (R * T^2)
     """
 
     def __init__(self):

--- a/particula/gas/vapor_pressure_builders.py
+++ b/particula/gas/vapor_pressure_builders.py
@@ -19,6 +19,27 @@ class AntoineBuilder(BuilderABC):
     coefficients 'a', 'b', and 'c' separately and then building the strategy
     object.
 
+    Example:
+        ``` py title="AntoineBuilder"
+        strategy = (
+            AntoineBuilder()
+            .set_a(8.07131)
+            .set_b(1730.63)
+            .set_c(233.426)
+            .build()
+        )
+        ```
+
+        ``` py title="AntoineBuilder with units"
+        strategy = (
+            AntoineBuilder()
+            .set_a(8.07131)
+            .set_b(1730.63, "K")
+            .set_c(233.426, "K")
+            .build()
+        )
+        ```
+
     References:
         - Equation: log10(P_mmHG) = a - b / (Temperature_K - c)
           (Reference: https://en.wikipedia.org/wiki/Antoine_equation)
@@ -71,6 +92,27 @@ class ClausiusClapeyronBuilder(BuilderABC):
     """Builder class for ClausiusClapeyronStrategy. This class facilitates
     setting the latent heat of vaporization, initial temperature, and initial
     pressure with unit handling and then builds the strategy object.
+
+    Example:
+        ``` py title="ClausiusClapeyronBuilder"
+        strategy = (
+            ClausiusClapeyronBuilder()
+            .set_latent_heat(2260)
+            .set_temperature_initial(373.15)
+            .set_pressure_initial(101325)
+            .build()
+        )
+        ```
+
+        ``` py title="ClausiusClapeyronBuilder with units"
+        strategy = (
+            ClausiusClapeyronBuilder()
+            .set_latent_heat(2260, "J/kg")
+            .set_temperature_initial(373.15, "K")
+            .set_pressure_initial(101325, "Pa")
+            .build()
+        )
+        ```
 
     References:
         - Equation: dP/dT = L / (R * T^2)
@@ -140,6 +182,23 @@ class ConstantBuilder(BuilderABC):
     """Builder class for ConstantVaporPressureStrategy. This class facilitates
     setting the constant vapor pressure and then building the strategy object.
 
+    Example:
+        ``` py title="ConstantBuilder"
+        strategy = (
+            ConstantBuilder()
+            .set_vapor_pressure(101325)
+            .build()
+        )
+        ```
+
+        ``` py title="ConstantBuilder with units"
+        strategy = (
+            ConstantBuilder()
+            .set_vapor_pressure(1, "atm")
+            .build()
+        )
+        ```
+
     References:
         - Equation: P = vapor_pressure
           https://en.wikipedia.org/wiki/Vapor_pressure
@@ -173,6 +232,11 @@ class WaterBuckBuilder(BuilderABC):  # pylint: disable=too-few-public-methods
     the building of the WaterBuckStrategy object. Which as of now has no
     additional parameters to set. But could be extended in the future for
     ice only calculations.
+
+    Example:
+        ``` py title="WaterBuckBuilder"
+        WaterBuckBuilder().build()
+        ```
     """
 
     def __init__(self):

--- a/particula/gas/vapor_pressure_builders.py
+++ b/particula/gas/vapor_pressure_builders.py
@@ -19,17 +19,9 @@ class AntoineBuilder(BuilderABC):
     coefficients 'a', 'b', and 'c' separately and then building the strategy
     object.
 
-    - Equation: log10(P_mmHG) = a - b / (Temperature_K - c)
-    - Units: 'a_units' = None, 'b_units' = 'K', 'c_units' = 'K'
-
-    Methods:
-        - set_a(a, a_units): Set the coefficient 'a' of the Antoine equation.
-        - set_b(b, b_units): Set the coefficient 'b' of the Antoine equation.
-        - set_c(c, c_units): Set the coefficient 'c' of the Antoine equation.
-        - set_parameters(params): Set coefficients from a dictionary including
-            optional units.
-        - build(): Build the AntoineVaporPressureStrategy object with the set
-            coefficients.
+    References:
+        - Equation: log10(P_mmHG) = a - b / (Temperature_K - c)
+          (Reference: https://en.wikipedia.org/wiki/Antoine_equation)
     """
 
     def __init__(self):
@@ -82,6 +74,7 @@ class ClausiusClapeyronBuilder(BuilderABC):
 
     References:
         - Equation: dP/dT = L / (R * T^2)
+          https://en.wikipedia.org/wiki/Clausius%E2%80%93Clapeyron_relation
     """
 
     def __init__(self):
@@ -147,17 +140,9 @@ class ConstantBuilder(BuilderABC):
     """Builder class for ConstantVaporPressureStrategy. This class facilitates
     setting the constant vapor pressure and then building the strategy object.
 
-    - Equation: P = vapor_pressure
-    - Units: 'vapor_pressure_units' = 'Pa'
-
-    Methods:
-    --------
-    - set_vapor_pressure(constant, constant_units): Set the constant vapor
-    pressure.
-    - set_parameters(parameters): Set parameters from a dictionary including
-        optional units.
-    - build(): Build the ConstantVaporPressureStrategy object with the set
-        parameters.
+    References:
+        - Equation: P = vapor_pressure
+          https://en.wikipedia.org/wiki/Vapor_pressure
     """
 
     def __init__(self):
@@ -187,11 +172,7 @@ class WaterBuckBuilder(BuilderABC):  # pylint: disable=too-few-public-methods
     """Builder class for WaterBuckStrategy. This class facilitates
     the building of the WaterBuckStrategy object. Which as of now has no
     additional parameters to set. But could be extended in the future for
-    ice only calculations. We keep the builder for consistency.
-
-    Methods:
-    --------
-    - build(): Build the WaterBuckStrategy object.
+    ice only calculations.
     """
 
     def __init__(self):

--- a/particula/gas/vapor_pressure_builders.py
+++ b/particula/gas/vapor_pressure_builders.py
@@ -53,7 +53,9 @@ class AntoineBuilder(BuilderABC):
         self.b = None
         self.c = None
 
-    def set_a(self, a: float, a_units: Optional[str] = None):
+    def set_a(
+        self, a: float, a_units: Optional[str] = None
+    ) -> "AntoineBuilder":
         """Set the coefficient 'a' of the Antoine equation."""
         if a < 0:
             logger.error("Coefficient 'a' must be a positive value.")
@@ -63,7 +65,7 @@ class AntoineBuilder(BuilderABC):
         self.a = a
         return self
 
-    def set_b(self, b: float, b_units: str = "K"):
+    def set_b(self, b: float, b_units: str = "K") -> "AntoineBuilder":
         """Set the coefficient 'b' of the Antoine equation."""
         if b < 0:
             logger.error("Coefficient 'b' must be a positive value.")
@@ -71,7 +73,7 @@ class AntoineBuilder(BuilderABC):
         self.b = convert_units(b_units, "K", b)
         return self
 
-    def set_c(self, c: float, c_units: str = "K"):
+    def set_c(self, c: float, c_units: str = "K") -> "AntoineBuilder":
         """Set the coefficient 'c' of the Antoine equation."""
         if c < 0:
             logger.error("Coefficient 'c' must be a positive value.")
@@ -79,7 +81,7 @@ class AntoineBuilder(BuilderABC):
         self.c = convert_units(c_units, "K", c)
         return self
 
-    def build(self):
+    def build(self) -> AntoineVaporPressureStrategy:
         """Build the AntoineVaporPressureStrategy object with the set
         coefficients."""
         self.pre_build_check()
@@ -132,7 +134,7 @@ class ClausiusClapeyronBuilder(BuilderABC):
 
     def set_latent_heat(
         self, latent_heat: float, latent_heat_units: str = "J/kg"
-    ):
+    ) -> "ClausiusClapeyronBuilder":
         """Set the latent heat of vaporization: Default units J/kg."""
         if latent_heat < 0:
             raise ValueError("Latent heat must be a positive numeric value.")
@@ -143,7 +145,7 @@ class ClausiusClapeyronBuilder(BuilderABC):
 
     def set_temperature_initial(
         self, temperature_initial: float, temperature_initial_units: str = "K"
-    ):
+    ) -> "ClausiusClapeyronBuilder":
         """Set the initial temperature. Default units: K."""
         if temperature_initial < 0:
             raise ValueError(
@@ -156,7 +158,7 @@ class ClausiusClapeyronBuilder(BuilderABC):
 
     def set_pressure_initial(
         self, pressure_initial: float, pressure_initial_units: str = "Pa"
-    ):
+    ) -> "ClausiusClapeyronBuilder":
         """Set the initial pressure. Default units: Pa."""
         if pressure_initial < 0:
             raise ValueError(
@@ -167,7 +169,7 @@ class ClausiusClapeyronBuilder(BuilderABC):
         )
         return self
 
-    def build(self):
+    def build(self) -> ClausiusClapeyronStrategy:
         """Build and return a ClausiusClapeyronStrategy object with the set
         parameters."""
         self.pre_build_check()
@@ -211,7 +213,7 @@ class ConstantBuilder(BuilderABC):
 
     def set_vapor_pressure(
         self, vapor_pressure: float, vapor_pressure_units: str = "Pa"
-    ):
+    ) -> "ConstantBuilder":
         """Set the constant vapor pressure."""
         if vapor_pressure < 0:
             raise ValueError("Vapor pressure must be a positive value.")
@@ -220,7 +222,7 @@ class ConstantBuilder(BuilderABC):
         )
         return self
 
-    def build(self):
+    def build(self) -> ConstantVaporPressureStrategy:
         """Build and return a ConstantVaporPressureStrategy object with the set
         parameters."""
         self.pre_build_check()
@@ -242,6 +244,6 @@ class WaterBuckBuilder(BuilderABC):  # pylint: disable=too-few-public-methods
     def __init__(self):
         super().__init__()
 
-    def build(self):
+    def build(self) -> WaterBuckStrategy:
         """Build and return a WaterBuckStrategy object."""
         return WaterBuckStrategy()

--- a/particula/gas/vapor_pressure_factories.py
+++ b/particula/gas/vapor_pressure_factories.py
@@ -39,30 +39,33 @@ class VaporPressureFactory(
     vapor pressure of gas species.
 
     Methods:
-        get_builders(): Returns the mapping of strategy types to builder
-        instances.
-        get_strategy(strategy_type, parameters): Gets the strategy instance
-        for the specified strategy type.
-            strategy_type: Type of vapor pressure strategy to use, can be
-            'constant', 'antoine', 'clausius_clapeyron', or 'water_buck'.
-            parameters(Dict[str, Any], optional): Parameters required for the
-            builder, dependent on the chosen strategy type.
-                - constant: constant_vapor_pressure
-                - antoine: A, B, C
-                - clausius_clapeyron: A, B, C
-                - water_buck: No parameters are required.
+        - get_builders : Returns the mapping of strategy types to builder
+            instances.
+        - get_strategy : Gets the strategy instance
+            for the specified strategy type.
+            - strategy_type : Type of vapor pressure strategy to use, can be
+                'constant', 'antoine', 'clausius_clapeyron', or 'water_buck'.
+            - parameters : Parameters required for the
+                builder, dependent on the chosen strategy type.
+                    - constant: constant_vapor_pressure
+                    - antoine: A, B, C
+                    - clausius_clapeyron: A, B, C
+                    - water_buck: No parameters are required.
 
     Returns:
-        VaporPressureStrategy: An instance of the specified
+        VaporPressureStrategy : An instance of the specified
             VaporPressureStrategy.
 
     Raises:
-        ValueError: If an unknown strategy type is provided.
-        ValueError: If any required key is missing during check_keys or
+        ValueError : If an unknown strategy type is provided.
+        ValueError : If any required key is missing during check_keys or
             pre_build_check, or if trying to set an invalid parameter.
 
     Example:
-    >>> strategy_is = VaporPressureFactory().get_strategy("constant")
+        ``` py title="constant vapor pressure strategy"
+        strategy_is = VaporPressureFactory().get_strategy("constant")
+        # returns ConstantVaporPressureStrategy
+        ```
     """
 
     def get_builders(self):

--- a/particula/gas/vapor_pressure_strategies.py
+++ b/particula/gas/vapor_pressure_strategies.py
@@ -104,8 +104,8 @@ class VaporPressureStrategy(ABC):
         temperature.
 
         Args:
-            molar_mass : Molar mass of the gas in kg/mol.
-            temperature : Temperature in Kelvin.
+            - molar_mass : Molar mass of the gas in kg/mol.
+            - temperature : Temperature in Kelvin.
 
         Returns:
             The saturation concentration of the gas in kg/m^3.
@@ -123,7 +123,7 @@ class VaporPressureStrategy(ABC):
         temperature. Units are in Pascals Pa=kg/(m·s²).
 
         Args:
-            temperature : Temperature in Kelvin.
+            - temperature : Temperature in Kelvin.
         """
 
 
@@ -141,13 +141,10 @@ class ConstantVaporPressureStrategy(VaporPressureStrategy):
         Return the constant vapor pressure value.
 
         Args:
-        ----
-        - temperature (float or NDArray[np.float64]): Not used.
+            - temperature : Not used.
 
         Returns:
-        -------
-        - vapor_pressure (float or NDArray[np.float64]): The constant vapor
-        pressure value in Pascals.
+            The constant vapor pressure value in Pascals.
         """
         # repeat the constant value for each element temperature
         return np.full_like(temperature, self.vapor_pressure)
@@ -176,8 +173,7 @@ class AntoineVaporPressureStrategy(VaporPressureStrategy):
         Calculate vapor pressure using the Antoine equation.
 
         Args:
-            a, b, c: Antoine equation parameters.
-            temperature: Temperature in Kelvin.
+            - temperature : Temperature in Kelvin.
 
         Returns:
             Vapor pressure in Pascals.
@@ -195,8 +191,7 @@ class AntoineVaporPressureStrategy(VaporPressureStrategy):
 
 class ClausiusClapeyronStrategy(VaporPressureStrategy):
     """Concrete implementation of the VaporPressureStrategy using the
-    Clausius-Clapeyron equation for vapor pressure calculations.
-    """
+    Clausius-Clapeyron equation for vapor pressure calculations."""
 
     def __init__(
         self,
@@ -206,17 +201,12 @@ class ClausiusClapeyronStrategy(VaporPressureStrategy):
     ):
         """
         Initializes the Clausius-Clapeyron strategy with the specific latent
-        heat
-        of vaporization and the specific gas constant of the substance.
+        heat of vaporization and the specific gas constant of the substance.
 
         Args:
-        ----
-        - latent_heat (float or NDArray[np.float64]): specific Latent heat of
-        in J/mol.
-        - temperature_initial (float or NDArray[np.float64]): Initial
-        temperature in Kelvin.
-        - pressure_initial (float or NDArray[np.float64]): Initial vapor
-        pressure in Pascals.
+            - latent_heat : Latent heat of vaporization in J/mol.
+            - temperature_initial : Initial temperature in Kelvin.
+            - pressure_initial : Initial vapor pressure in Pascals.
         """
         self.latent_heat = latent_heat
         self.temperature_initial = temperature_initial
@@ -229,11 +219,7 @@ class ClausiusClapeyronStrategy(VaporPressureStrategy):
         Calculate vapor pressure using Clausius-Clapeyron equation.
 
         Args:
-            latent_heat: Latent heat of vaporization in J/mol.
-            temperature_initial: Initial temperature in Kelvin.
-            pressure_initial: Initial vapor pressure in Pascals.
-            temperature: Final temperature in Kelvin.
-            gas_constant: gas constant (default is 8.314 J/(mol·K)).
+            - temperature : Final temperature in Kelvin.
 
         Returns:
             Pure vapor pressure in Pascals.
@@ -260,15 +246,15 @@ class WaterBuckStrategy(VaporPressureStrategy):
         Calculate vapor pressure using the Buck equation for water vapor.
 
         Args:
-            temperature: Temperature in Kelvin.
+            - temperature : Temperature in Kelvin.
 
         Returns:
             Vapor pressure in Pascals.
 
         References:
             - Buck, A. L., 1981: New Equations for Computing Vapor Pressure and
-                Enhancement Factor. J. Appl. Meteor. Climatol., 20, 1527-1532,
-                https://doi.org/10.1175/1520-0450(1981)020<1527:NEFCVP>2.0.CO;2.
+              Enhancement Factor. J. Appl. Meteor. Climatol., 20, 1527-1532,
+              https://doi.org/10.1175/1520-0450(1981)020<1527:NEFCVP>2.0.CO;2.
             - https://en.wikipedia.org/wiki/Arden_Buck_equation
         """
         return buck_vapor_pressure(temperature)

--- a/particula/gas/vapor_pressure_strategies.py
+++ b/particula/gas/vapor_pressure_strategies.py
@@ -321,4 +321,3 @@ class WaterBuckStrategy(VaporPressureStrategy):
             - https://en.wikipedia.org/wiki/Arden_Buck_equation
         """
         return buck_vapor_pressure(temperature)
- 

--- a/particula/gas/vapor_pressure_strategies.py
+++ b/particula/gas/vapor_pressure_strategies.py
@@ -46,6 +46,15 @@ class VaporPressureStrategy(ABC):
 
         Returns:
             Partial pressure of the gas in Pascals.
+
+        Examples:
+            ``` py title="Partial Pressure Calculation"
+            partial_pressure = strategy.partial_pressure(
+                concentration=5.0,
+                molar_mass=18.01528,
+                temperature=298.15
+            )
+            ```
         """
         return calculate_partial_pressure(
             concentration, molar_mass, temperature
@@ -68,6 +77,15 @@ class VaporPressureStrategy(ABC):
 
         Returns:
             The concentration of the gas in kg/m^3.
+
+        Examples:
+            ``` py title="Concentration Calculation"
+            concentration = strategy.concentration(
+                partial_pressure=101325,
+                molar_mass=18.01528,
+                temperature=298.15
+            )
+            ```
         """
         return calculate_concentration(
             partial_pressure, molar_mass, temperature
@@ -89,6 +107,15 @@ class VaporPressureStrategy(ABC):
 
         Returns:
             The saturation ratio of the gas.
+
+        Examples:
+            ``` py title="Saturation Ratio Calculation"
+            saturation_ratio = strategy.saturation_ratio(
+                concentration=5.0,
+                molar_mass=18.01528,
+                temperature=298.15
+            )
+            ```
         """
         return self.partial_pressure(
             concentration, molar_mass, temperature
@@ -109,6 +136,14 @@ class VaporPressureStrategy(ABC):
 
         Returns:
             The saturation concentration of the gas in kg/m^3.
+
+        Examples:
+            ``` py title="Saturation Concentration Calculation"
+            saturation_concentration = strategy.saturation_concentration(
+                molar_mass=18.01528,
+                temperature=298.15
+            )
+            ```
         """
 
         return self.concentration(
@@ -145,6 +180,13 @@ class ConstantVaporPressureStrategy(VaporPressureStrategy):
 
         Returns:
             The constant vapor pressure value in Pascals.
+
+        Examples:
+            ``` py title="Constant Vapor Pressure Calculation"
+            vapor_pressure = strategy.pure_vapor_pressure(
+                temperature=300
+            )
+            ```
         """
         # repeat the constant value for each element temperature
         return np.full_like(temperature, self.vapor_pressure)
@@ -177,6 +219,13 @@ class AntoineVaporPressureStrategy(VaporPressureStrategy):
 
         Returns:
             Vapor pressure in Pascals.
+
+        Examples:
+            ``` py title="Antoine Vapor Pressure Calculation"
+            vapor_pressure = strategy.pure_vapor_pressure(
+                temperature=300
+            )
+            ```
 
         References:
             - Equation: log10(P) = a - b / (T - c)
@@ -224,6 +273,13 @@ class ClausiusClapeyronStrategy(VaporPressureStrategy):
         Returns:
             Pure vapor pressure in Pascals.
 
+        Examples:
+            ``` py title="Clausius-Clapeyron Vapor Pressure Calculation"
+            vapor_pressure = strategy.pure_vapor_pressure(
+                temperature=300
+            )
+            ```
+
         References:
             - https://en.wikipedia.org/wiki/Clausius%E2%80%93Clapeyron_relation
         """
@@ -246,10 +302,17 @@ class WaterBuckStrategy(VaporPressureStrategy):
         Calculate vapor pressure using the Buck equation for water vapor.
 
         Args:
-            - temperature : Temperature in Kelvin.
+            - temperature: Temperature in Kelvin.
 
         Returns:
             Vapor pressure in Pascals.
+
+        Examples:
+            ``` py title="Water Buck Vapor Pressure Calculation"
+            vapor_pressure = strategy.pure_vapor_pressure(
+                temperature=300
+            )
+            ```
 
         References:
             - Buck, A. L., 1981: New Equations for Computing Vapor Pressure and
@@ -258,3 +321,4 @@ class WaterBuckStrategy(VaporPressureStrategy):
             - https://en.wikipedia.org/wiki/Arden_Buck_equation
         """
         return buck_vapor_pressure(temperature)
+ 

--- a/particula/gas/vapor_pressure_strategies.py
+++ b/particula/gas/vapor_pressure_strategies.py
@@ -40,14 +40,12 @@ class VaporPressureStrategy(ABC):
         mass, and temperature.
 
         Args:
-            concentration (float or NDArray[np.float64]): Concentration of the
-                gas in kg/m^3.
-            molar_mass (float or NDArray[np.float64]): Molar mass of the gas in
-                kg/mol.
-            temperature (float or NDArray[np.float64]): Temperature in Kelvin.
+            - concentration : Concentration of the gas in kg/m^3.
+            - molar_mass : Molar mass of the gas in kg/mol.
+            - temperature : Temperature in Kelvin.
 
         Returns:
-            partial_pressure: Partial pressure of the gas in Pascals.
+            Partial pressure of the gas in Pascals.
         """
         return calculate_partial_pressure(
             concentration, molar_mass, temperature
@@ -64,12 +62,12 @@ class VaporPressureStrategy(ABC):
         temperature.
 
         Args:
-            partial_pressure: Pressure in Pascals.
-            molar_mass: Molar mass of the gas in kg/mol.
-            temperature: Temperature in Kelvin.
+            - partial_pressure: Pressure in Pascals.
+            - molar_mass: Molar mass of the gas in kg/mol.
+            - temperature: Temperature in Kelvin.
 
         Returns:
-            concentration: The concentration of the gas in kg/m^3.
+            The concentration of the gas in kg/m^3.
         """
         return calculate_concentration(
             partial_pressure, molar_mass, temperature
@@ -86,11 +84,11 @@ class VaporPressureStrategy(ABC):
         temperature.
 
         Args:
-            pressure: Pressure in Pascals.
-            temperature: Temperature in Kelvin.
+           - pressure : Pressure in Pascals.
+           - temperature : Temperature in Kelvin.
 
         Returns:
-            saturation_ratio: The saturation ratio of the gas.
+            The saturation ratio of the gas.
         """
         return self.partial_pressure(
             concentration, molar_mass, temperature
@@ -106,15 +104,11 @@ class VaporPressureStrategy(ABC):
         temperature.
 
         Args:
-        ----
-        - molar_mass (float or NDArray[np.float64]): Molar mass of the gas in
-        kg/mol.
-        - temperature (float or NDArray[np.float64]): Temperature in Kelvin.
+            molar_mass : Molar mass of the gas in kg/mol.
+            temperature : Temperature in Kelvin.
 
         Returns:
-        -------
-        - saturation_concentration (float or NDArray[np.float64]):
-        The saturation concentration of the gas in kg/m^3.
+            The saturation concentration of the gas in kg/m^3.
         """
 
         return self.concentration(
@@ -129,7 +123,7 @@ class VaporPressureStrategy(ABC):
         temperature. Units are in Pascals Pa=kg/(m·s²).
 
         Args:
-            temperature (float or NDArray[np.float64]): Temperature in Kelvin.
+            temperature : Temperature in Kelvin.
         """
 
 


### PR DESCRIPTION
Cleaned up ABC builder, and vapor pressure strategy/builder docs, removed mixin reference

added example calls to doc strings, so they get generated in the mkdocs references

fixes #475 

## Summary by Sourcery

Documentation:
- Clean up the documentation for the ABC builder by removing references to mixin classes and updating the format for arguments, methods, and raises sections.

## Summary by Sourcery

Documentation:
- Add example code snippets to docstrings for better clarity and understanding of usage.