### PR TITLE
Add merge-group to gh-page deployment cases

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -40,6 +40,9 @@ jobs:
 
         - name: Deploy to GitHub Pages (on push or merge_group)
           if: github.event_name == 'push' || github.event_name == 'merge_group'
+          concurrency:
+            group: "pages"
+            cancel-in-progress: true
           uses: JamesIves/github-pages-deploy-action@v4
           with:
             branch: gh-pages

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -38,8 +38,8 @@ jobs:
         - name: Build MkDocs site and Run Jupyter Books
           run: mkdocs build
 
-        - name: Deploy to GitHub Pages (on push)
-          if: github.event_name == 'push'
+        - name: Deploy to GitHub Pages (on push or merge_group)
+          if: github.event_name == 'push' || github.event_name == 'merge_group'
           uses: JamesIves/github-pages-deploy-action@v4
           with:
             branch: gh-pages

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -15,6 +15,9 @@ on:
 jobs:
   blds:
     runs-on: ubuntu-latest
+    concurrency:
+      group: "pages"
+      cancel-in-progress: true
     steps:
         - name: Check out code
           uses: actions/checkout@v4
@@ -40,9 +43,6 @@ jobs:
 
         - name: Deploy to GitHub Pages (on push or merge_group)
           if: github.event_name == 'push' || github.event_name == 'merge_group'
-          concurrency:
-            group: "pages"
-            cancel-in-progress: true
           uses: JamesIves/github-pages-deploy-action@v4
           with:
             branch: gh-pages


### PR DESCRIPTION
Fixes #524
When gh-pages from the merge-group were not being deployed

## Summary by Sourcery

CI:
- Update GitHub Actions workflow to deploy gh-pages on both push and merge_group events.