### PR TITLE
Particle resolved, check intersect1d performance

### DIFF
--- a/particula/dynamics/coagulation/particle_resolved_method.py
+++ b/particula/dynamics/coagulation/particle_resolved_method.py
@@ -136,7 +136,8 @@ def particle_resolved_update_step(
     return particle_radius, loss, gain
 
 
-# pylint: disable=too-many-positional-arguments, too-many-arguments, too-many-locals
+# pylint: disable=too-many-positional-arguments, too-many-arguments
+# pylint: disable=too-many-locals
 def particle_resolved_coagulation_step(
     particle_radius: NDArray[np.float64],
     kernel: NDArray[np.float64],

--- a/particula/dynamics/coagulation/tests/particle_resolved_method_test.py
+++ b/particula/dynamics/coagulation/tests/particle_resolved_method_test.py
@@ -2,6 +2,7 @@
 
 import time
 import numpy as np
+from scipy.interpolate import RectBivariateSpline
 from particula.dynamics.coagulation.particle_resolved_method import (
     interpolate_kernel,
     calculate_probabilities,
@@ -9,7 +10,6 @@ from particula.dynamics.coagulation.particle_resolved_method import (
     particle_resolved_update_step,
     particle_resolved_coagulation_step,
 )
-from scipy.interpolate import RectBivariateSpline
 
 
 def test_interpolate_kernel():

--- a/particula/dynamics/coagulation/tests/particle_resolved_method_test.py
+++ b/particula/dynamics/coagulation/tests/particle_resolved_method_test.py
@@ -1,7 +1,7 @@
 """pytest tests for particle_resolved_method.py"""
 
-import numpy as np
 import time
+import numpy as np
 from particula.dynamics.coagulation.particle_resolved_method import (
     interpolate_kernel,
     calculate_probabilities,

--- a/particula/dynamics/coagulation/tests/particle_resolved_method_test.py
+++ b/particula/dynamics/coagulation/tests/particle_resolved_method_test.py
@@ -1,0 +1,120 @@
+"""pytest tests for particle_resolved_method.py"""
+
+import numpy as np
+import time
+from particula.dynamics.coagulation.particle_resolved_method import (
+    interpolate_kernel,
+    calculate_probabilities,
+    resolve_final_coagulation_state,
+    particle_resolved_update_step,
+    particle_resolved_coagulation_step,
+)
+from scipy.interpolate import RectBivariateSpline
+
+
+def test_interpolate_kernel():
+    """Test the interpolate_kernel function."""
+    kernel = np.random.rand(10, 10)
+    kernel_radius = np.linspace(0, 1, 10)
+    interp_func = interpolate_kernel(kernel, kernel_radius)
+    assert isinstance(interp_func, RectBivariateSpline)
+
+
+def test_calculate_probabilities():
+    """Test the calculate_probabilities function."""
+    kernel_values = np.array([1.0, 2.0], dtype=np.float64)
+    time_step = 1.0
+    events = 10
+    tests = 5
+    volume = 100.0
+    probabilities = calculate_probabilities(
+        kernel_values, time_step, events, tests, volume
+    )
+    expected_probabilities = (
+        kernel_values * time_step * events / (tests * volume)
+    )
+    np.testing.assert_array_almost_equal(probabilities, expected_probabilities)
+
+
+def test_resolve_final_coagulation_state():
+    small_indices = np.array([0, 1, 2], dtype=np.int64)
+    large_indices = np.array([2, 3, 4], dtype=np.int64)
+    particle_radius = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float64)
+    updated_small_indices, updated_large_indices = (
+        resolve_final_coagulation_state(
+            small_indices, large_indices, particle_radius
+        )
+    )
+    assert len(updated_small_indices) == len(small_indices)
+    assert len(updated_large_indices) == len(large_indices)
+
+
+def test_resolve_final_coagulation_state_large():
+    """Test the resolve_final_coagulation_state function with a
+    large number of particles."""
+    num_particles = 100000
+    small_indices = np.random.randint(
+        0, num_particles, size=num_particles // 2, dtype=np.int64
+    )
+    large_indices = np.random.randint(
+        0, num_particles, size=num_particles // 2, dtype=np.int64
+    )
+    particle_radius = np.random.uniform(1.0, 10.0, size=num_particles).astype(
+        np.float64
+    )
+
+    # Introduce duplicate collisions
+    small_indices[:10] = large_indices[:10]
+
+    # Time the function
+    start_time = time.time()
+    updated_small_indices, updated_large_indices = (
+        resolve_final_coagulation_state(
+            small_indices, large_indices, particle_radius
+        )
+    )
+    end_time = time.time()
+    elapsed_time = end_time - start_time
+    time_per_particle = elapsed_time / num_particles
+    current_version_time_per_particle = 1e-05
+
+    # incase we change the implementation and it is slower
+    assert time_per_particle <= current_version_time_per_particle
+
+    assert len(updated_small_indices) == len(small_indices)
+    assert len(updated_large_indices) == len(large_indices)
+
+
+def test_particle_resolved_update_step():
+    """Test the particle_resolved_update_step function."""
+    particle_radius = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    loss = np.zeros_like(particle_radius)
+    gain = np.zeros_like(particle_radius)
+    small_index = np.array([0], dtype=np.int64)
+    large_index = np.array([1], dtype=np.int64)
+    updated_radius, updated_loss, updated_gain = particle_resolved_update_step(
+        particle_radius, loss, gain, small_index, large_index
+    )
+    assert updated_radius[0] == 0
+    assert updated_radius[1] > 2.0
+    assert updated_loss[0] == 1.0
+    assert updated_gain[1] == 2.0
+
+
+def test_particle_resolved_coagulation_step():
+    """Test the particle_resolved_coagulation_step function."""
+    particle_radius = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    kernel = np.random.rand(10, 10)
+    kernel_radius = np.linspace(0, 1, 10)
+    volume = 100.0
+    time_step = 1.0
+    random_generator = np.random.default_rng(seed=42)
+    loss_gain_index = particle_resolved_coagulation_step(
+        particle_radius,
+        kernel,
+        kernel_radius,
+        volume,
+        time_step,
+        random_generator,
+    )
+    assert loss_gain_index.shape[1] == 2

--- a/particula/dynamics/coagulation/tests/particle_resolved_method_test.py
+++ b/particula/dynamics/coagulation/tests/particle_resolved_method_test.py
@@ -37,6 +37,7 @@ def test_calculate_probabilities():
 
 
 def test_resolve_final_coagulation_state():
+    """Test the resolve_final_coagulation_state function."""
     small_indices = np.array([0, 1, 2], dtype=np.int64)
     large_indices = np.array([2, 3, 4], dtype=np.int64)
     particle_radius = np.array([1.0, 2.0, 3.0, 4.0, 5.0], dtype=np.float64)

--- a/particula/dynamics/coagulation/tests/particle_resolved_method_test.py
+++ b/particula/dynamics/coagulation/tests/particle_resolved_method_test.py
@@ -52,7 +52,7 @@ def test_resolve_final_coagulation_state():
 def test_resolve_final_coagulation_state_large():
     """Test the resolve_final_coagulation_state function with a
     large number of particles."""
-    num_particles = 100000
+    num_particles = 100_000
     small_indices = np.random.randint(
         0, num_particles, size=num_particles // 2, dtype=np.int64
     )


### PR DESCRIPTION
Fixes #478

wrote some test for the particle resolved functions.

I tried a dict method to replace intersect, but same performance up to a million particles. So, I added a timing test, to check if future changes make it any slower

## Summary by Sourcery

Tests:
- Add comprehensive tests for particle resolved functions including interpolate_kernel, calculate_probabilities, resolve_final_coagulation_state, particle_resolved_update_step, and particle_resolved_coagulation_step.

## Summary by Sourcery

Tests:
- Add comprehensive tests for particle resolved functions including interpolate_kernel, calculate_probabilities, resolve_final_coagulation_state, particle_resolved_update_step, and particle_resolved_coagulation_step.