### PR TITLE
remove linting and docs from merge group

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,8 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-  merge_group:
-    branches: [ main ]
 
 jobs:
   linting:

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -9,8 +9,6 @@ on:
       - main
     paths:
       - 'docs/**'
-  merge_group:
-    branches: [ main ]
 
 jobs:
   blds:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Remove linting and documentation workflows from the merge group trigger.