### PR TITLE
Add Integral Scale functions

### DIFF
--- a/particula/gas/properties/__init__.py
+++ b/particula/gas/properties/__init__.py
@@ -29,3 +29,7 @@ from particula.gas.properties.vapor_pressure_module import (
 from particula.gas.properties.kolmogorov_time import (
     get_kolmogorov_time
 )
+from particula.gas.properties.integral_scale_module import (
+    get_lagrangian_integral_scale,
+    get_eulerian_integral_scale,
+)

--- a/particula/gas/properties/integral_scale_module.py
+++ b/particula/gas/properties/integral_scale_module.py
@@ -1,0 +1,77 @@
+"""
+Calculate a fluids integral scale.
+"""
+
+from typing import Union
+from numpy.typing import NDArray
+import numpy as np
+
+from particula.util.validate_inputs import validate_inputs
+
+
+@validate_inputs(
+    {"rms_velocity": "positive", "turbulent_dissipation": "positive"}
+)
+def get_lagrangian_integral_scale(
+    rms_velocity: Union[float, NDArray[np.float64]],
+    turbulent_dissipation: Union[float, NDArray[np.float64]],
+) -> Union[float, NDArray[np.float64]]:
+    """
+    Calculate the Lagrangian integral timescale.
+
+    The Lagrangian integral scale (T_L) characterizes the timescale of large
+    eddies in turbulence. This represents the correlation time of fluid
+    elements in turbulent motion. It is given by:
+
+        T_L = u'^2 / ε
+
+    where:
+        - T_L : Lagrangian integral timescale [s]
+        - u' (rms_velocity) : Fluid RMS fluctuation velocity [m/s]
+        - ε (turbulent_dissipation) : Turbulent energy dissipation rate [m²/s³]
+
+    Arguments:
+    ----------
+        - rms_velocity : Fluid RMS fluctuation velocity [m/s]
+        - turbulent_dissipation : Turbulent kinetic energy dissipation rate
+            [m²/s³]
+
+    Returns:
+    --------
+        - Lagrangian integral timescale [s]
+    """
+    return (rms_velocity**2) / turbulent_dissipation
+
+
+@validate_inputs(
+    {"rms_velocity": "positive", "turbulent_dissipation": "positive"}
+)
+def get_eulerian_integral_scale(
+    rms_velocity: Union[float, NDArray[np.float64]],
+    turbulent_dissipation: Union[float, NDArray[np.float64]],
+) -> Union[float, NDArray[np.float64]]:
+    """
+    Calculate the Eulerian integral length scale.
+
+    The Eulerian integral length scale (L_e) represents the characteristic
+    size of the largest turbulent eddies and provides insight into the spatial
+    correlation of turbulence structures. It is given by:
+
+        L_e = 0.5 * u'^3 / ε
+
+    where:
+        - L_e : Eulerian integral length scale [m]
+        - u' (rms_velocity) : Fluid RMS fluctuation velocity [m/s]
+        - ε (turbulent_dissipation) : Turbulent energy dissipation rate [m²/s³]
+
+    Arguments:
+    ----------
+        - rms_velocity : Fluid RMS fluctuation velocity [m/s]
+        - turbulent_dissipation : Turbulent kinetic energy dissipation rate
+            [m²/s³]
+
+    Returns:
+    --------
+        - Eulerian integral length scale [m]
+    """
+    return 0.5 * (rms_velocity**3) / turbulent_dissipation

--- a/particula/gas/properties/tests/integral_scale_module_test.py
+++ b/particula/gas/properties/tests/integral_scale_module_test.py
@@ -91,15 +91,15 @@ def test_integral_scales_edge_case():
     rms_velocity = 1e-10
     turbulent_dissipation = 1e-10
 
-    expected_TL = (rms_velocity**2) / turbulent_dissipation
-    expected_Le = 0.5 * (rms_velocity**3) / turbulent_dissipation
+    expected_tl = (rms_velocity**2) / turbulent_dissipation
+    expected_le = 0.5 * (rms_velocity**3) / turbulent_dissipation
 
-    result_TL = get_lagrangian_integral_scale(
+    result_tl = get_lagrangian_integral_scale(
         rms_velocity, turbulent_dissipation
     )
-    result_Le = get_eulerian_integral_scale(
+    result_le = get_eulerian_integral_scale(
         rms_velocity, turbulent_dissipation
     )
 
-    assert np.isclose(result_TL, expected_TL, atol=1e-10)
-    assert np.isclose(result_Le, expected_Le, atol=1e-10)
+    assert np.isclose(result_tl, expected_tl, atol=1e-10)
+    assert np.isclose(result_le, expected_le, atol=1e-10)

--- a/particula/gas/properties/tests/integral_scale_module_test.py
+++ b/particula/gas/properties/tests/integral_scale_module_test.py
@@ -1,0 +1,105 @@
+"""
+Test the integral scale functions in the integral_scale_module.py file.
+"""
+
+import pytest
+import numpy as np
+from particula.gas.properties.integral_scale_module import (
+    get_lagrangian_integral_scale,
+    get_eulerian_integral_scale,
+)
+
+
+def test_get_lagrangian_integral_scale_scalar():
+    """
+    Test get_lagrangian_integral_scale with scalar inputs.
+    """
+    rms_velocity = 0.5  # m/s
+    turbulent_dissipation = 1e-3  # m²/s³
+
+    expected = (rms_velocity**2) / turbulent_dissipation
+    result = get_lagrangian_integral_scale(rms_velocity, turbulent_dissipation)
+
+    assert np.isclose(result, expected, atol=1e-10)
+
+
+def test_get_lagrangian_integral_scale_array():
+    """
+    Test get_lagrangian_integral_scale with NumPy array inputs.
+    """
+    rms_velocity = np.array([0.5, 0.8])
+    turbulent_dissipation = np.array([1e-3, 2e-3])
+
+    expected = (rms_velocity**2) / turbulent_dissipation
+    result = get_lagrangian_integral_scale(rms_velocity, turbulent_dissipation)
+
+    assert np.allclose(result, expected, atol=1e-10)
+
+
+def test_get_lagrangian_integral_scale_invalid_values():
+    """
+    Test that get_lagrangian_integral_scale raises errors for invalid inputs.
+    """
+    with pytest.raises(ValueError):
+        get_lagrangian_integral_scale(-0.5, 1e-3)
+
+    with pytest.raises(ValueError):
+        get_lagrangian_integral_scale(0.5, -1e-3)
+
+
+def test_get_eulerian_integral_scale_scalar():
+    """
+    Test get_eulerian_integral_scale with scalar inputs.
+    """
+    rms_velocity = 0.5  # m/s
+    turbulent_dissipation = 1e-3  # m²/s³
+
+    expected = 0.5 * (rms_velocity**3) / turbulent_dissipation
+    result = get_eulerian_integral_scale(rms_velocity, turbulent_dissipation)
+
+    assert np.isclose(result, expected, atol=1e-10)
+
+
+def test_get_eulerian_integral_scale_array():
+    """
+    Test get_eulerian_integral_scale with NumPy array inputs.
+    """
+    rms_velocity = np.array([0.5, 0.8])
+    turbulent_dissipation = np.array([1e-3, 2e-3])
+
+    expected = 0.5 * (rms_velocity**3) / turbulent_dissipation
+    result = get_eulerian_integral_scale(rms_velocity, turbulent_dissipation)
+
+    assert np.allclose(result, expected, atol=1e-10)
+
+
+def test_get_eulerian_integral_scale_invalid_values():
+    """
+    Test that get_eulerian_integral_scale raises errors for invalid inputs.
+    """
+    with pytest.raises(ValueError):
+        get_eulerian_integral_scale(-0.5, 1e-3)
+
+    with pytest.raises(ValueError):
+        get_eulerian_integral_scale(0.5, -1e-3)
+
+
+def test_integral_scales_edge_case():
+    """
+    Test both integral scale functions with very small values near machine precision.
+    """
+    rms_velocity = 1e-10
+    turbulent_dissipation = 1e-10
+
+    expected_TL = (rms_velocity**2) / turbulent_dissipation
+    expected_Le = 0.5 * (rms_velocity**3) / turbulent_dissipation
+
+    result_TL = get_lagrangian_integral_scale(
+        rms_velocity, turbulent_dissipation
+    )
+    result_Le = get_eulerian_integral_scale(
+        rms_velocity, turbulent_dissipation
+    )
+
+    assert np.isclose(result_TL, expected_TL, atol=1e-10)
+    assert np.isclose(result_Le, expected_Le, atol=1e-10)


### PR DESCRIPTION
Fixes #574

Added     get_lagrangian_integral_scale, get_eulerian_integral_scale, 
and tests for each

## Summary by Sourcery

Add functions to calculate Lagrangian and Eulerian integral scales.

New Features:
- Added `get_lagrangian_integral_scale` and `get_eulerian_integral_scale` functions to calculate the respective integral scales.

Tests:
- Added tests for the new integral scale functions.