### PR TITLE
Changed Diameter to Radius in Shear Kernel

### DIFF
--- a/particula/dynamics/coagulation/tests/turbulent_shear_kernel_test.py
+++ b/particula/dynamics/coagulation/tests/turbulent_shear_kernel_test.py
@@ -29,7 +29,7 @@ def test_turbulent_shear_kernel_single_value():
         diameter_particle[:, np.newaxis] + diameter_particle[np.newaxis, :]
     ) ** 3
     value = saffman_turner_1956(
-        diameter_particle, turbulent_kinetic_energy, kinematic_viscosity
+        diameter_particle/2, turbulent_kinetic_energy, kinematic_viscosity
     )
     np.testing.assert_allclose(value, expected_kernel, rtol=1e-6)
 
@@ -38,7 +38,7 @@ def test_turbulent_shear_kernel_via_system_state():
     """
     Test turbulent_shear_kernel_via_system_state with system state inputs.
     """
-    diameter_particle = np.array([1e-6, 2e-6])  # example diameters [m]
+    particle_radius = np.array([1e-6, 2e-6])  # example diameters [m]
     turbulent_kinetic_energy = (
         1.0e-4  # example turbulent kinetic energy [m^2/s^2]
     )
@@ -48,10 +48,10 @@ def test_turbulent_shear_kernel_via_system_state():
         temperature=temperature, fluid_density=fluid_density
     )
     expected_kernel = saffman_turner_1956(
-        diameter_particle, turbulent_kinetic_energy, kinematic_viscosity
+        particle_radius, turbulent_kinetic_energy, kinematic_viscosity
     )
     value = saffman_turner_1956_via_system_state(
-        diameter_particle, turbulent_kinetic_energy, temperature, fluid_density
+        particle_radius, turbulent_kinetic_energy, temperature, fluid_density
     )
     np.testing.assert_allclose(value, expected_kernel, rtol=1e-6)
 

--- a/particula/dynamics/coagulation/turbulent_shear_kernel.py
+++ b/particula/dynamics/coagulation/turbulent_shear_kernel.py
@@ -24,7 +24,7 @@ from particula.gas.properties.kinematic_viscosity import (
 
 
 def saffman_turner_1956(
-    diameter_particle: NDArray[np.float64],
+    particle_radius: NDArray[np.float64],
     turbulent_kinetic_energy: float,
     kinematic_viscosity: float,
 ) -> NDArray[np.float64]:
@@ -33,7 +33,7 @@ def saffman_turner_1956(
 
     Args:
     -----
-        - diameter_particle : Array of particle diameters [m].
+        - particle_radius : Array of particle diameters [m].
         - turbulent_kinetic_energy : Turbulent kinetic energy [m^2/s^2].
         - kinematic_viscosity : Kinematic viscosity [m^2/s].
 
@@ -55,15 +55,16 @@ def saffman_turner_1956(
         physics, Chapter 13, Equation 13A.2.
     """
     diameter_sum_matrix = (
-        diameter_particle[:, np.newaxis] + diameter_particle[np.newaxis, :]
-    )
+        particle_radius[:, np.newaxis] + particle_radius[np.newaxis, :]
+    ) * 2  # Convert from radius to diameter sum
+
     return (
         np.pi * turbulent_kinetic_energy / (120 * kinematic_viscosity)
     ) ** 0.5 * diameter_sum_matrix**3
 
 
 def saffman_turner_1956_via_system_state(
-    diameter_particle: NDArray[np.float64],
+    particle_radius: NDArray[np.float64],
     turbulent_kinetic_energy: float,
     temperature: float,
     fluid_density: float,
@@ -73,7 +74,7 @@ def saffman_turner_1956_via_system_state(
 
     Args:
     -----
-        - diameter_particle : Array of particle diameters [m].
+        - particle_radius : Array of particle diameters [m].
         - turbulent_kinetic_energy : Turbulent kinetic energy [m^2/s^2].
         - temperature : Temperature of the system [K].
         - fluid_density : Density of the fluid [kg/m^3].
@@ -92,7 +93,7 @@ def saffman_turner_1956_via_system_state(
         temperature=temperature, fluid_density=fluid_density
     )
     return saffman_turner_1956(
-        diameter_particle=diameter_particle,
+        particle_radius=particle_radius,
         turbulent_kinetic_energy=turbulent_kinetic_energy,
         kinematic_viscosity=kinematic_viscosity,
     )

--- a/particula/dynamics/coagulation/turbulent_shear_kernel.py
+++ b/particula/dynamics/coagulation/turbulent_shear_kernel.py
@@ -33,7 +33,7 @@ def saffman_turner_1956(
 
     Args:
     -----
-        - particle_radius : Array of particle diameters [m].
+        - particle_radius : Array of particle radii [m].
         - turbulent_kinetic_energy : Turbulent kinetic energy [m^2/s^2].
         - kinematic_viscosity : Kinematic viscosity [m^2/s].
 
@@ -74,7 +74,7 @@ def saffman_turner_1956_via_system_state(
 
     Args:
     -----
-        - particle_radius : Array of particle diameters [m].
+        - particle_radius : Array of particle radii [m].
         - turbulent_kinetic_energy : Turbulent kinetic energy [m^2/s^2].
         - temperature : Temperature of the system [K].
         - fluid_density : Density of the fluid [kg/m^3].


### PR DESCRIPTION
Fixes #598

Change input to radius

## Summary by Sourcery

Bug Fixes:
- Fix issue #598 where the diameter was used instead of the radius.