### PR TITLE
Add the Psi Function for Geometric Kernel

### DIFF
--- a/particula/dynamics/coagulation/turbulent_dns_kernel/psi_ao2008.py
+++ b/particula/dynamics/coagulation/turbulent_dns_kernel/psi_ao2008.py
@@ -1,0 +1,64 @@
+"""
+Psi function for the droplet collision kernel in the turbulent DNS model.
+"""
+from typing import Union
+import numpy as np
+from numpy.typing import NDArray
+
+from particula.util.validate_inputs import validate_inputs
+
+
+@validate_inputs(
+    {
+        "alpha": "positive",
+        "phi": "positive",
+        "particle_inertia_time": "positive",
+        "particle_velocity": "positive",
+    }
+)
+def get_psi_ao2008(
+    alpha: Union[float, NDArray[np.float64]],
+    phi: Union[float, NDArray[np.float64]],
+    particle_inertia_time: Union[float, NDArray[np.float64]],
+    particle_velocity: Union[float, NDArray[np.float64]],
+) -> Union[float, NDArray[np.float64]]:
+    """
+    Compute the function Ψ(α, φ) for the k-th droplet.
+
+    The function Ψ(α, φ) is defined as:
+
+        Ψ(α, φ) = 1 / ((1/τ_pk) + (1/α) + (v_pk/φ))
+                - (v_pk / (2φ ((1/τ_pk) + (1/α) + (v_pk/φ))^2))
+
+    - τ_pk (particle_inertia_time) : Inertia timescale of the k-th droplet
+        [s].
+    - α : A parameter related to turbulence and droplet interactions [-].
+    - φ : A characteristic velocity or timescale parameter [m/s].
+    - v_pk (particle_velocity) : Velocity of the k-th droplet [m/s].
+
+    Arguments:
+    ----------
+        - alpha : A parameter related to turbulence and droplet interactions
+            [-].
+        - phi : A characteristic velocity or timescale parameter [m/s].
+        - particle_inertia_time : Inertia timescale of the droplet τ_pk [s].
+        - particle_velocity : Velocity of the droplet v_pk [m/s].
+
+    Returns:
+    --------
+        - Ψ(α, φ) value [-].
+
+    References:
+    -----------
+    - Ayala, O., Rosa, B., & Wang, L. P. (2008). Effects of turbulence on
+        the geometric collision rate of sedimenting droplets. Part 2.
+        Theory and parameterization. New Journal of Physics, 10.
+        https://doi.org/10.1088/1367-2630/10/7/075016
+    """
+    denominator = (
+        (1 / particle_inertia_time) + (1 / alpha) + (particle_velocity / phi)
+    )
+    return (
+        1 / denominator
+        - (particle_velocity / (2 * phi * denominator**2))
+    )

--- a/particula/dynamics/coagulation/turbulent_dns_kernel/tests/psi_ao2008_test.py
+++ b/particula/dynamics/coagulation/turbulent_dns_kernel/tests/psi_ao2008_test.py
@@ -1,0 +1,123 @@
+"""
+Test psi function from Ayala et al. (2008).
+"""
+
+import pytest
+import numpy as np
+from particula.dynamics.coagulation.turbulent_dns_kernel.psi_ao2008 import (
+    get_psi_ao2008,
+)
+
+
+def test_get_psi_ao2008_scalar():
+    """
+    Test get_psi_ao2008 with scalar inputs.
+    """
+    alpha = 2.0  # Turbulence parameter [-]
+    phi = 1.0  # Characteristic velocity [m/s]
+    particle_inertia_time = 0.05  # [s]
+    particle_velocity = 0.1  # [m/s]
+
+    expected = 1 / (
+        (1 / particle_inertia_time) + (1 / alpha) + (particle_velocity / phi)
+    ) - (
+        particle_velocity
+        / (
+            2
+            * phi
+            * (
+                (1 / particle_inertia_time)
+                + (1 / alpha)
+                + (particle_velocity / phi)
+            )
+            ** 2
+        )
+    )
+
+    result = get_psi_ao2008(
+        alpha, phi, particle_inertia_time, particle_velocity
+    )
+
+    assert np.isclose(
+        result, expected, atol=1e-10
+    ), f"Expected {expected}, but got {result}"
+
+
+def test_get_psi_ao2008_array():
+    """
+    Test get_psi_ao2008 with NumPy array inputs.
+    """
+    alpha = 2.0  # Turbulence parameter [-]
+    phi = 1.0  # Characteristic velocity [m/s]
+    particle_inertia_time = np.array([0.05, 0.1, 0.2])  # [s]
+    particle_velocity = np.array([0.1, 0.2, 0.3])  # [m/s]
+
+    denominator = (
+        (1 / particle_inertia_time) + (1 / alpha) + (particle_velocity / phi)
+    )
+    expected = 1 / denominator - (
+        particle_velocity / (2 * phi * denominator**2)
+    )
+
+    result = get_psi_ao2008(
+        alpha, phi, particle_inertia_time, particle_velocity
+    )
+
+    assert (
+        result.shape == expected.shape
+    ), f"Expected shape {expected.shape}, but got {result.shape}"
+    assert np.allclose(
+        result, expected, atol=1e-10
+    ), f"Expected {expected}, but got {result}"
+
+
+def test_get_psi_ao2008_invalid_inputs():
+    """
+    Test that get_psi_ao2008 raises validation errors for invalid inputs.
+    """
+    alpha = 2.0  # [-]
+    phi = 1.0  # [m/s]
+    particle_inertia_time = np.array([0.05, 0.1, 0.2])  # [s]
+    particle_velocity = np.array([0.1, 0.2, 0.3])  # [m/s]
+
+    with pytest.raises(ValueError):
+        get_psi_ao2008(
+            -alpha, phi, particle_inertia_time, particle_velocity
+        )  # Negative alpha
+
+    with pytest.raises(ValueError):
+        get_psi_ao2008(
+            alpha, -phi, particle_inertia_time, particle_velocity
+        )  # Negative phi
+
+    with pytest.raises(ValueError):
+        get_psi_ao2008(
+            alpha, phi, -particle_inertia_time, particle_velocity
+        )  # Negative inertia time
+
+    with pytest.raises(ValueError):
+        get_psi_ao2008(
+            alpha, phi, particle_inertia_time, -particle_velocity
+        )  # Negative velocity
+
+
+def test_get_psi_ao2008_edge_cases():
+    """
+    Test get_psi_ao2008 with extreme values such as very small or very large
+    values.
+    """
+    alpha = 2.0  # [-]
+    phi = 1.0  # [m/s]
+    particle_inertia_time = np.array(
+        [1e-6, 1e-3, 10.0]
+    )  # Very small and large inertia values
+    particle_velocity = np.array(
+        [1e-6, 1e-3, 10.0]
+    )  # Very small and large velocities
+
+    result = get_psi_ao2008(
+        alpha, phi, particle_inertia_time, particle_velocity
+    )
+
+    assert np.all(result >= 0), "Expected all values to be non-negative"
+    assert np.isfinite(result).all(), "Expected all values to be finite"


### PR DESCRIPTION
Fixes #594

## Summary by Sourcery

Tests:
- Add tests for the psi function, covering various scenarios such as scalar and array inputs, invalid inputs, and edge cases.