### PR TITLE
Add DNS Radial Velocity functions

### DIFF
--- a/particula/dynamics/coagulation/turbulent_dns_kernel/radial_velocity_module.py
+++ b/particula/dynamics/coagulation/turbulent_dns_kernel/radial_velocity_module.py
@@ -1,0 +1,113 @@
+"""
+Radial relative velocity calculation module.
+"""
+
+from typing import Union
+import numpy as np
+from numpy.typing import NDArray
+from scipy.special import erf
+
+from particula.util.validate_inputs import validate_inputs
+from particula.util.constants import STANDARD_GRAVITY
+
+
+@validate_inputs(
+    {
+        "velocity_dispersion": "positive",
+        "particle_inertia_time": "positive",
+    }
+)
+def get_radial_relative_velocity_dz2002(
+    velocity_dispersion: Union[float, NDArray[np.float64]],
+    particle_inertia_time: NDArray[np.float64],
+) -> Union[float, NDArray[np.float64]]:
+    """
+    Compute the radial relative velocity based on the Dodin and Elperin (2002)
+    formulation.
+
+    The relative velocity is given by:
+
+        ⟨ |w_r| ⟩ = sqrt(2 / π) * σ * f(b)
+
+    - f(b) = (1/2) sqrt(π) (b + 0.5 / b) erf(b) + (1/2) exp(-b^2)
+    - b = g |τ_p1 - τ_p2| / (sqrt(2) σ)
+    - σ : Turbulence velocity dispersion [m/s]
+    - τ_p1, τ_p2 : Inertia timescale of particles 1 and 2 [s]
+    - g : Gravitational acceleration [m/s²]
+
+    Arguments:
+    ----------
+        - velocity_dispersion : Turbulence velocity dispersion (σ) [m/s].
+        - particle_inertia_time : Inertia timescale of particles (τ_p) [s].
+
+    Returns:
+    --------
+        - Radial relative velocity ⟨ |w_r| ⟩ [m/s].
+
+    References:
+    -----------
+    - Dodin, Z., & Elperin, T. (2002). Phys. Fluids, 14, 2921-24.
+    """
+    tau_diff = np.abs(
+        particle_inertia_time[:, np.newaxis]
+        - particle_inertia_time[np.newaxis, :]
+    )
+    b = (STANDARD_GRAVITY * tau_diff) / (np.sqrt(2) * velocity_dispersion)
+
+    # Compute f(b)
+    sqrt_pi = np.sqrt(np.pi)
+    erf_b = erf(b)
+    exp_b2 = np.exp(-(b**2))
+    f_b = (
+        0.5 * sqrt_pi * (b + 0.5 / np.maximum(b, 1e-12)) * erf_b + 0.5 * exp_b2
+    )
+
+    return np.sqrt(2 / np.pi) * velocity_dispersion * f_b
+
+
+@validate_inputs(
+    {
+        "velocity_dispersion": "positive",
+        "particle_inertia_time": "positive",
+    }
+)
+def get_radial_relative_velocity_ao2008(
+    velocity_dispersion: Union[float, NDArray[np.float64]],
+    particle_inertia_time: Union[float, NDArray[np.float64]],
+) -> Union[float, NDArray[np.float64]]:
+    """
+    Compute the radial relative velocity based on the Ayala et al. (2008)
+    formulation.
+
+    The relative velocity is given by:
+
+        ⟨ |w_r| ⟩ = sqrt(2 / π) * sqrt(σ² + (π/8) * (τ_p1 + τ_p2)² * |g|²)
+
+    - σ : Turbulence velocity dispersion [m/s]
+    - τ_p1, τ_p2 : Inertia timescale of particles 1 and 2 [s]
+    - g : Gravitational acceleration [m/s²]
+
+
+    Arguments:
+    ----------
+        - velocity_dispersion : Turbulence velocity dispersion (σ) [m/s].
+        - particle_inertia_time : Inertia timescale of particle 1 (τ_p1) [s].
+
+    Returns:
+    --------
+        - Radial relative velocity ⟨ |w_r| ⟩ [m/s].
+
+    References:
+    -----------
+    - Ayala, O., Rosa, B., & Wang, L. P. (2008). Effects of turbulence on
+        the geometric collision rate of sedimenting droplets. Part 2.
+        Theory and parameterization. New Journal of Physics, 10.
+        https://doi.org/10.1088/1367-2630/10/7/075016
+    """
+    tau_sum = (
+        particle_inertia_time[:, np.newaxis]
+        + particle_inertia_time[np.newaxis, :]
+    )
+    gravity_term = (np.pi / 8) * tau_sum**2 * STANDARD_GRAVITY**2
+
+    return np.sqrt(2 / np.pi) * np.sqrt(velocity_dispersion**2 + gravity_term)

--- a/particula/dynamics/coagulation/turbulent_dns_kernel/tests/radial_velocity_module_test.py
+++ b/particula/dynamics/coagulation/turbulent_dns_kernel/tests/radial_velocity_module_test.py
@@ -1,0 +1,101 @@
+"""
+Test the radial relative velocity formulations.
+"""
+
+import pytest
+import numpy as np
+from particula.dynamics.coagulation.turbulent_dns_kernel.radial_velocity_module import (
+    get_radial_relative_velocity_dz2002,
+    get_radial_relative_velocity_ao2008,
+)
+
+
+def test_get_radial_relative_velocity_dz2002():
+    """
+    Test get_radial_relative_velocity_dz2002 with a small array input.
+    """
+    velocity_dispersion = 0.1  # m/s
+    particle_inertia_time = np.array([0.02, 0.03, 0.05])  # s
+
+    expected_shape = (3, 3)
+    result = get_radial_relative_velocity_dz2002(
+        velocity_dispersion, particle_inertia_time
+    )
+
+    assert (
+        result.shape == expected_shape
+    ), f"Expected shape {expected_shape}, but got {result.shape}"
+    assert np.all(result >= 0), "Expected all values to be non-negative"
+
+
+def test_get_radial_relative_velocity_ao2008():
+    """
+    Test get_radial_relative_velocity_ao2008 with a small array input.
+    """
+    velocity_dispersion = 0.1  # m/s
+    particle_inertia_time = np.array([0.02, 0.03, 0.05])  # s
+
+    expected_shape = (3, 3)
+    result = get_radial_relative_velocity_ao2008(
+        velocity_dispersion, particle_inertia_time
+    )
+
+    assert (
+        result.shape == expected_shape
+    ), f"Expected shape {expected_shape}, but got {result.shape}"
+    assert np.all(result >= 0), "Expected all values to be non-negative"
+
+
+def test_invalid_inputs():
+    """
+    Ensure validation errors are raised for invalid inputs.
+    """
+    velocity_dispersion = 0.1  # m/s
+    particle_inertia_time = np.array([0.02, 0.03, 0.05])  # s
+
+    with pytest.raises(ValueError):
+        get_radial_relative_velocity_dz2002(
+            -velocity_dispersion, particle_inertia_time
+        )  # Negative dispersion
+
+    with pytest.raises(ValueError):
+        get_radial_relative_velocity_dz2002(
+            velocity_dispersion, -particle_inertia_time
+        )  # Negative inertia
+
+    with pytest.raises(ValueError):
+        get_radial_relative_velocity_ao2008(
+            -velocity_dispersion, particle_inertia_time
+        )  # Negative dispersion
+
+    with pytest.raises(ValueError):
+        get_radial_relative_velocity_ao2008(
+            velocity_dispersion, -particle_inertia_time
+        )  # Negative inertia
+
+
+def test_edge_cases():
+    """
+    Test the function with extreme values such as zero inertia and very large
+    inertia.
+    """
+    velocity_dispersion = 0.1  # m/s
+    particle_inertia_time = np.array(
+        [0.01, 1e-6, 10.0]
+    )  # Small and large inertia values
+
+    wr_dz2002 = get_radial_relative_velocity_dz2002(
+        velocity_dispersion, particle_inertia_time
+    )
+
+    wr_ao2008 = get_radial_relative_velocity_ao2008(
+        velocity_dispersion, particle_inertia_time
+    )
+
+    # Ensure no negative values
+    assert np.all(wr_dz2002 >= 0), "Expected all values to be non-negative"
+    assert np.all(wr_ao2008 >= 0), "Expected all values to be non-negative"
+
+    # Ensure numerical stability for large inertia values
+    assert np.isfinite(wr_dz2002).all(), "Expected all values to be finite"
+    assert np.isfinite(wr_ao2008).all(), "Expected all values to be finite"


### PR DESCRIPTION
Fixes #590 

Add both methods used for radial velocity calculations

## Summary by Sourcery

New Features:
- Add functions to compute radial relative velocity using the Dodin and Elperin (2002) and Ayala et al. (2008) formulations.