### PR TITLE
Add the droplet geometric kernel function

### DIFF
--- a/particula/dynamics/coagulation/turbulent_dns_kernel/kernel_ao2008.py
+++ b/particula/dynamics/coagulation/turbulent_dns_kernel/kernel_ao2008.py
@@ -1,0 +1,98 @@
+"""
+Calculate the geometric collision kernel Γ₁₂ (or K₁₂) based on turbulent
+DNS simulations.
+"""
+
+from typing import Union
+import numpy as np
+from numpy.typing import NDArray
+
+from particula.util.validate_inputs import validate_inputs
+from particula.dynamics.coagulation.turbulent_dns_kernel.radial_velocity_module import (
+    get_radial_relative_velocity_ao2008,
+)
+from particula.dynamics.coagulation.turbulent_dns_kernel.g12_radial_distribution_ao2008 import (
+    get_g12_radial_distribution_ao2008,
+)
+
+
+@validate_inputs(
+    {
+        "particle_radius": "positive",
+        "velocity_dispersion": "positive",
+        "particle_inertia_time": "positive",
+    }
+)
+def get_kernel_ao2008(
+    particle_radius: Union[float, NDArray[np.float64]],
+    velocity_dispersion: Union[float, NDArray[np.float64]],
+    particle_inertia_time: Union[float, NDArray[np.float64]],
+    stokes_number: Union[float, NDArray[np.float64]],
+    kolmogorov_length_scale: float,
+    reynolds_lambda: float,
+    normalized_accel_variance: float,
+    kolmogorov_velocity: float,
+    kolmogorov_time: float,
+) -> Union[float, NDArray[np.float64]]:
+    # pylint: disable=too-many-arguments, too-many-positional-arguments
+    """
+    Get the geometric collision kernel Γ₁₂.
+
+        Γ₁₂ = 2π R² ⟨ |w_r| ⟩ g₁₂
+
+    - R = a₁ + a₂ (collision radius)
+    - ⟨ |w_r| ⟩ : Radial relative velocity, computed using
+        `get_radial_relative_velocity_ao2008`
+    - g₁₂ : Radial distribution function, computed using
+        `g12_radial_distribution`
+    - radius << η (Kolmogorov length scale)
+    - ρ_w >> ρ (water density much greater than air density)
+    - Sv > 1 (Stokes number sufficiently large)
+
+    Arguments:
+    ----------
+        - particle_radius : Particle radius [m].
+        - velocity_dispersion : Velocity dispersion [m/s].
+        - particle_inertia_time : Particle inertia time [s].
+        - stokes_number : Stokes number [-].
+        - kolmogorov_length_scale : Kolmogorov length scale [m].
+        - reynolds_lambda : Reynolds number [-].
+        - normalized_accel_variance : Normalized acceleration variance [-].
+        - kolmogorov_velocity : Kolmogorov velocity [m/s].
+        - kolmogorov_time : Kolmogorov time [s].
+
+    Returns:
+    --------
+        - Collision kernel Γ₁₂ [m³/s].
+
+    References:
+    -----------
+    - Ayala, O., Rosa, B., & Wang, L. P. (2008). Effects of turbulence on
+        the geometric collision rate of sedimenting droplets. Part 2.
+        Theory and parameterization. New Journal of Physics, 10.
+        https://doi.org/10.1088/1367-2630/10/7/075016
+    """
+    collision_radius = (
+        particle_radius[:, np.newaxis] + particle_radius[np.newaxis, :]
+    )
+
+    # Compute radial relative velocity ⟨ |w_r| ⟩
+    wr = get_radial_relative_velocity_ao2008(
+        velocity_dispersion, particle_inertia_time
+    )
+
+    # Compute radial distribution function g₁₂
+    g12 = get_g12_radial_distribution_ao2008(
+        particle_radius,
+        stokes_number,
+        kolmogorov_length_scale,
+        reynolds_lambda,
+        normalized_accel_variance,
+        kolmogorov_velocity,
+        kolmogorov_time,
+    )
+
+    # Compute collision kernel Γ₁₂
+    gamma_12 = 2 * np.pi * collision_radius**2 * wr * g12
+
+    return gamma_12

--- a/particula/dynamics/coagulation/turbulent_dns_kernel/tests/g12_radial_distribution_ao2008_test.py
+++ b/particula/dynamics/coagulation/turbulent_dns_kernel/tests/g12_radial_distribution_ao2008_test.py
@@ -1,3 +1,4 @@
+# pylint: disable=duplicate-code
 """
 Test the radial distribution of the coagulation kernel g12 using the
 AO2008 DNS model.
@@ -38,7 +39,7 @@ def test_get_g12_radial_distribution_ao2008_scalar():
         normalized_accel_variance,
         kolmogorov_velocity,
         kolmogorov_time,
-    )  # pylint: disable=duplicate-code
+    )
 
     # Check the shape
     assert g12_matrix.shape == (
@@ -72,7 +73,7 @@ def test_get_g12_radial_distribution_ao2008_invalid_inputs():
             normalized_accel_variance,
             kolmogorov_velocity,
             kolmogorov_time,
-        )  # pylint: disable=duplicate-code
+        )
 
     with pytest.raises(ValueError):
         get_g12_radial_distribution_ao2008(
@@ -83,7 +84,7 @@ def test_get_g12_radial_distribution_ao2008_invalid_inputs():
             normalized_accel_variance,
             kolmogorov_velocity,
             kolmogorov_time,
-        )  # pylint: disable=duplicate-code
+        )
 
     with pytest.raises(ValueError):
         get_g12_radial_distribution_ao2008(
@@ -94,7 +95,7 @@ def test_get_g12_radial_distribution_ao2008_invalid_inputs():
             normalized_accel_variance,
             kolmogorov_velocity,
             kolmogorov_time,
-        )  # pylint: disable=duplicate-code
+        )
 
     with pytest.raises(ValueError):
         get_g12_radial_distribution_ao2008(
@@ -105,7 +106,7 @@ def test_get_g12_radial_distribution_ao2008_invalid_inputs():
             normalized_accel_variance,
             kolmogorov_velocity,
             kolmogorov_time,
-        )  # pylint: disable=duplicate-code
+        )
 
 
 def test_get_g12_radial_distribution_ao2008_edge_cases():
@@ -131,7 +132,7 @@ def test_get_g12_radial_distribution_ao2008_edge_cases():
         normalized_accel_variance,
         kolmogorov_velocity,
         kolmogorov_time,
-    )  # pylint: disable=duplicate-code
+    )
 
     assert g12_matrix.shape == (
         3,

--- a/particula/dynamics/coagulation/turbulent_dns_kernel/tests/g12_radial_distribution_ao2008_test.py
+++ b/particula/dynamics/coagulation/turbulent_dns_kernel/tests/g12_radial_distribution_ao2008_test.py
@@ -38,7 +38,7 @@ def test_get_g12_radial_distribution_ao2008_scalar():
         normalized_accel_variance,
         kolmogorov_velocity,
         kolmogorov_time,
-    )
+    )  # pylint: disable=duplicate-code
 
     # Check the shape
     assert g12_matrix.shape == (
@@ -72,7 +72,7 @@ def test_get_g12_radial_distribution_ao2008_invalid_inputs():
             normalized_accel_variance,
             kolmogorov_velocity,
             kolmogorov_time,
-        )
+        )  # pylint: disable=duplicate-code
 
     with pytest.raises(ValueError):
         get_g12_radial_distribution_ao2008(
@@ -83,7 +83,7 @@ def test_get_g12_radial_distribution_ao2008_invalid_inputs():
             normalized_accel_variance,
             kolmogorov_velocity,
             kolmogorov_time,
-        )
+        )  # pylint: disable=duplicate-code
 
     with pytest.raises(ValueError):
         get_g12_radial_distribution_ao2008(
@@ -94,7 +94,7 @@ def test_get_g12_radial_distribution_ao2008_invalid_inputs():
             normalized_accel_variance,
             kolmogorov_velocity,
             kolmogorov_time,
-        )
+        )  # pylint: disable=duplicate-code
 
     with pytest.raises(ValueError):
         get_g12_radial_distribution_ao2008(
@@ -105,7 +105,7 @@ def test_get_g12_radial_distribution_ao2008_invalid_inputs():
             normalized_accel_variance,
             kolmogorov_velocity,
             kolmogorov_time,
-        )
+        )  # pylint: disable=duplicate-code
 
 
 def test_get_g12_radial_distribution_ao2008_edge_cases():
@@ -131,7 +131,7 @@ def test_get_g12_radial_distribution_ao2008_edge_cases():
         normalized_accel_variance,
         kolmogorov_velocity,
         kolmogorov_time,
-    )
+    )  # pylint: disable=duplicate-code
 
     assert g12_matrix.shape == (
         3,

--- a/particula/dynamics/coagulation/turbulent_dns_kernel/tests/kernel_ao2008_test.py
+++ b/particula/dynamics/coagulation/turbulent_dns_kernel/tests/kernel_ao2008_test.py
@@ -1,0 +1,103 @@
+"""
+Tests that the collision kernel function can be evaluated get_kernel_ao2008.
+"""
+
+import unittest
+import numpy as np
+from particula.dynamics.coagulation.turbulent_dns_kernel.kernel_ao2008 import (
+    get_kernel_ao2008,
+)
+
+
+class TestKernelAO2008(unittest.TestCase):
+    # pylint: disable=too-many-instance-attributes
+    """Unit tests for the collision kernel function get_kernel_ao2008."""
+
+    def setUp(self):
+        """Set up common test parameters."""
+        self.stokes_number_scalar = 0.5  # [-]
+        self.kolmogorov_length_scale = 1e-6  # [m]
+        self.reynolds_lambda = 100  # [-]
+        self.normalized_accel_variance = 11  # [-]
+        self.kolmogorov_velocity = 0.01  # [m/s]
+        self.kolmogorov_time = 0.005  # [s]
+
+        # Array-based test inputs
+        self.particle_radius_array = np.array([10e-6, 20e-6, 30e-6])  # [m]
+        self.particle_inertia_time_array = np.array([0.02, 0.03, 0.05])  # [s]
+        self.stokes_number_array = np.array([0.5, 0.6, 0.7])  # [-]
+        self.velocity_dispersion_scalar = 0.1  # [m/s]
+
+    def test_get_kernel_ao2008_array(self):
+        """Test get_kernel_ao2008 with NumPy array inputs."""
+        result = get_kernel_ao2008(
+            self.particle_radius_array,
+            self.velocity_dispersion_scalar,
+            self.particle_inertia_time_array,
+            self.stokes_number_array,
+            self.kolmogorov_length_scale,
+            self.reynolds_lambda,
+            self.normalized_accel_variance,
+            self.kolmogorov_velocity,
+            self.kolmogorov_time,
+        )
+
+        self.assertEqual(
+            result.shape,
+            (3, 3),
+            f"Expected shape (3, 3), but got {result.shape}",
+        )
+
+    def test_invalid_inputs(self):
+        """Ensure validation errors are raised for invalid inputs."""
+        with self.assertRaises(ValueError):
+            get_kernel_ao2008(
+                -1*self.particle_radius_array,
+                self.velocity_dispersion_scalar,
+                self.particle_inertia_time_array,
+                self.stokes_number_array,
+                self.kolmogorov_length_scale,
+                self.reynolds_lambda,
+                self.normalized_accel_variance,
+                self.kolmogorov_velocity,
+                self.kolmogorov_time,
+            )  # Negative radius
+
+        with self.assertRaises(ValueError):
+            get_kernel_ao2008(
+                self.particle_radius_array,
+                -1*self.velocity_dispersion_scalar,
+                self.particle_inertia_time_array,
+                self.stokes_number_array,
+                self.kolmogorov_length_scale,
+                self.reynolds_lambda,
+                self.normalized_accel_variance,
+                self.kolmogorov_velocity,
+                self.kolmogorov_time,
+            )  # Negative velocity_dispersion
+
+        with self.assertRaises(ValueError):
+            get_kernel_ao2008(
+                self.particle_radius_array,
+                self.velocity_dispersion_scalar,
+                -1*self.particle_inertia_time_array,
+                self.stokes_number_array,
+                self.kolmogorov_length_scale,
+                self.reynolds_lambda,
+                self.normalized_accel_variance,
+                self.kolmogorov_velocity,
+                self.kolmogorov_time,
+            )  # Negative particle_inertia_time
+
+        with self.assertRaises(ValueError):
+            get_kernel_ao2008(
+                self.particle_radius_array,
+                self.velocity_dispersion_scalar,
+                self.particle_inertia_time_array,
+                -1*self.stokes_number_array,
+                self.kolmogorov_length_scale,
+                self.reynolds_lambda,
+                self.normalized_accel_variance,
+                self.kolmogorov_velocity,
+                self.kolmogorov_time,
+            )  # Negative stokes_number


### PR DESCRIPTION
Fixes #589

Added the base function for the dns kernel.
A separate issue (#608) will address going from system observables to this function.

## Summary by Sourcery

Implement the turbulent DNS collision kernel function based on Ayala et al. (2008). Add input validation for positive values of particle radius, velocity dispersion, and particle inertia time.

New Features:
- Calculate the geometric collision kernel for turbulent DNS based on Ayala et al. (2008).

Tests:
- Include unit tests to verify the collision kernel calculation and validate inputs.