### PR TITLE
Force used of correct dependencies for np.trapezoid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 ]
 
 dependencies = [
-    "numpy", "scipy",
+    "numpy>=2.0.0", "scipy>=1.12",
 ]
 
 # This is set automatically by flit using `particula.__version__`


### PR DESCRIPTION
The GPT interactive console install was using old numpy, we use >2.0.

## Summary by Sourcery

Enhancements:
- Enforce minimum versions of numpy (>=2.0.0) and scipy (>=1.12).