### PR TITLE
Update __init__.py

### DIFF
--- a/particula/__init__.py
+++ b/particula/__init__.py
@@ -30,7 +30,7 @@ from particula.aerosol import Aerosol
 
 from particula.logger_setup import setup
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 
 # setup the logger
 logger = setup()


### PR DESCRIPTION
forced numpy>2.0
new release

## Summary by Sourcery

Update the package version to 0.2.1 and enforce numpy>2.0.

Chores:
- Update the package version to 0.2.1.
- Enforce numpy>2.0.