### PR TITLE
Addressed warnings in tests and added to vscode testing workflow.

### DIFF
--- a/particula/activity/gibbs_mixing.py
+++ b/particula/activity/gibbs_mixing.py
@@ -81,8 +81,11 @@ def gibbs_of_mixing(
     sum1 = c1 + c2 * (1 - 2 * phi2)
     gibbs_mix = phi2 * (1.0 - phi2) * sum1
 
-    dphi2dx2 = (scaled_molar_mass_ratio / rhor) * (
-        phi2 / organic_mole_fraction
+    # Initialize result with zeros
+    dphi2dx2 = np.zeros_like(organic_mole_fraction)
+    non_zero = organic_mole_fraction != 0
+    dphi2dx2[non_zero] = (scaled_molar_mass_ratio / rhor) * (
+        phi2[non_zero] / organic_mole_fraction[non_zero]
     ) ** 2
 
     derivative_gibbs_mix = (

--- a/particula/activity/water_activity.py
+++ b/particula/activity/water_activity.py
@@ -236,4 +236,8 @@ def fixed_water_activity(
         activities_beta = np.flip(activities_beta)
         q_alpha = np.flip(q_alpha)
 
+    activities_alpha = np.asarray(activities_alpha, dtype=np.float64)
+    activities_beta = np.asarray(activities_beta, dtype=np.float64)
+    q_alpha = np.asarray(q_alpha, dtype=np.float64)
+
     return (activities_alpha, activities_beta, q_alpha)

--- a/particula/dynamics/coagulation/particle_resolved_step/particle_resolved_method.py
+++ b/particula/dynamics/coagulation/particle_resolved_step/particle_resolved_method.py
@@ -137,7 +137,9 @@ def get_particle_resolved_coagulation_step(
 
         # Step 7: Determine the number of coagulation tests to run based
         # on kernel value and system parameters
-        tests = int(np.ceil(kernel_values * time_step * events / volume))
+        tests = int(
+            np.ceil(kernel_values.item() * time_step * events / volume)
+        )
         if tests == 0 or events == 0:
             continue
 

--- a/particula/dynamics/coagulation/turbulent_dns_kernel/g12_radial_distribution_ao2008.py
+++ b/particula/dynamics/coagulation/turbulent_dns_kernel/g12_radial_distribution_ao2008.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from particula.util.validate_inputs import validate_inputs
 from particula.util.constants import STANDARD_GRAVITY
-from particula.util.machine_limit import get_safe_exp
+from particula.util.machine_limit import get_safe_exp, get_safe_power
 
 
 @validate_inputs(
@@ -50,18 +50,16 @@ def get_g12_radial_distribution_ao2008(
     - g (gravitational_acceleration) : Gravitational acceleration [m/s²]
 
     Arguments:
-    ----------
-    - particle_radius : Array of particle radii [m]
-    - stokes_number : Array of Stokes numbers of particles [-]
-    - kolmogorov_length_scale : Kolmogorov length scale [m]
-    - reynolds_lambda : Taylor-microscale Reynolds number [-]
-    - normalized_accel_variance : Normalized acceleration variance [-]
-    - kolmogorov_velocity : Kolmogorov velocity scale [m/s]
-    - kolmogorov_time : Kolmogorov timescale [s]
+        - particle_radius : Array of particle radii [m]
+        - stokes_number : Array of Stokes numbers of particles [-]
+        - kolmogorov_length_scale : Kolmogorov length scale [m]
+        - reynolds_lambda : Taylor-microscale Reynolds number [-]
+        - normalized_accel_variance : Normalized acceleration variance [-]
+        - kolmogorov_velocity : Kolmogorov velocity scale [m/s]
+        - kolmogorov_time : Kolmogorov timescale [s]
 
     Returns:
-    --------
-    - Radial distribution function g_{12} [-]
+        - Radial distribution function g_{12} [-]
 
     References:
     -----------
@@ -126,7 +124,7 @@ def _calculate_c1(
         kolmogorov_velocity / kolmogorov_time
     )
 
-    return y_stokes / np.power(gravity_term, f3_lambda)
+    return y_stokes / get_safe_power(gravity_term, f3_lambda)
 
 
 def _compute_y_stokes(

--- a/particula/equilibria/partitioning.py
+++ b/particula/equilibria/partitioning.py
@@ -235,15 +235,14 @@ def get_properties_for_liquid_vapor_partitioning(
             oxygen2carbon=oxy,
             density=density[i],
         )
-
-        gamma_organic_ab[i, 0] = alpha[-1]
-        mass_fraction_water_ab[i, 0] = alpha[2]
+        gamma_organic_ab[i, 0] = alpha[-1][0]
+        mass_fraction_water_ab[i, 0] = alpha[2][0]
         if beta is None:
             gamma_organic_ab[i, 1] = 0
             mass_fraction_water_ab[i, 1] = 0
         else:
-            gamma_organic_ab[i, 1] = beta[-1]
-            mass_fraction_water_ab[i, 1] = beta[2]
-        q_ab[i, 0] = q_alpha
-        q_ab[i, 1] = 1 - q_alpha
+            gamma_organic_ab[i, 1] = beta[-1][0]
+            mass_fraction_water_ab[i, 1] = beta[2][0]
+        q_ab[i, 0] = q_alpha[0]
+        q_ab[i, 1] = 1 - q_alpha[0]
     return gamma_organic_ab, mass_fraction_water_ab, q_ab

--- a/particula/particles/change_particle_representation.py
+++ b/particula/particles/change_particle_representation.py
@@ -115,18 +115,23 @@ def get_speciated_mass_representation_from_particle_resolved(
 
     # loop through the bins and get the median
     for index, _ in enumerate(bin_radius):
-        if old_distribution.ndim == 1:
-            new_distribution[index] = np.median(
-                old_distribution[bin_indexes == index]
-            )
+        mask = bin_indexes == index
+        if np.any(mask):
+            if old_distribution.ndim == 1:
+                new_distribution[index] = np.median(old_distribution[mask])
+            else:
+                new_distribution[index, :] = np.mean(old_distribution[mask, :])
+            new_charge[index] = np.median(old_charge[mask])
+            new_concentration[index] = np.sum(old_concentration[mask])
         else:
-            new_distribution[index, :] = np.mean(
-                old_distribution[bin_indexes == index, :]
-            )
-        new_charge[index] = np.median(old_charge[bin_indexes == index])
-        new_concentration[index] = np.sum(
-            old_concentration[bin_indexes == index]
-        )
+            # Default behavior when the bin is empty:
+            if old_distribution.ndim == 1:
+                new_distribution[index] = np.nan
+            else:
+                new_distribution[index, :] = np.nan
+            new_charge[index] = np.nan
+            new_concentration[index] = 0
+
     # check for nans and all zeros in the new distribution
     mask_nan_zeros = np.isnan(new_distribution) | (new_distribution == 0)
 

--- a/particula/util/tests/machine_limit_test.py
+++ b/particula/util/tests/machine_limit_test.py
@@ -6,6 +6,7 @@ from particula.util.machine_limit import (
     get_safe_exp,
     get_safe_log,
     get_safe_log10,
+    get_safe_power,
 )
 
 
@@ -64,3 +65,36 @@ def test_safe_log10():
             get_safe_log10([-1, -2, -3]), np.log10([-1, -2, -3])
         )
         assert any(item.category == RuntimeWarning for item in w)
+
+
+def test_safe_power():
+    """Test get_safe_power function."""
+
+    # Test with typical positive values:
+    base = np.array([2, 3, 10])
+    exponent = np.array([3, 2, 1])
+    # For valid positive inputs, get_safe_power should match np.power.
+    assert np.allclose(
+        get_safe_power(base, exponent), np.power(base, exponent)
+    )
+
+    # Test for overflow protection:
+    # Compute the safe exponent limit for base 10.
+    max_exp_input = np.log(np.finfo(np.float64).max)
+    safe_exponent = max_exp_input / np.log(10)
+    # Use an exponent slightly above the safe limit.
+    base_overflow = np.array([10])
+    exponent_overflow = np.array([safe_exponent + 1])
+    result_overflow = get_safe_power(base_overflow, exponent_overflow)
+    expected_overflow = np.array([np.finfo(np.float64).max])
+    assert np.allclose(result_overflow, expected_overflow)
+
+    # Test with zero base:
+    # raise value error if base is zero and exponent is negative.
+    with np.testing.assert_raises(ValueError):
+        get_safe_power(0, -1)
+
+    # Test with negative base:
+    # raise value error if base is negative and exponent is not an integer.
+    with np.testing.assert_raises(ValueError):
+        get_safe_power(-1, 0.5)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+filterwarnings = error


### PR DESCRIPTION
Fixes #653 

Addressed warnings in tests. I had relaxed these in DNS kernel development.
Added warning pytext.ini, so that the warnings as errors show up in the vscode workflow.

They are now evident when writing new code as it is completed, before it was not that way on local machines by default (only on PRs)

## Summary by Sourcery

Addresses warnings in tests and integrates them into the VS Code testing workflow, ensuring that warnings are treated as errors during local development.

Tests:
- Adds a test case for the `get_safe_power` function to ensure correct behavior with positive values, overflow protection, and handling of zero and negative bases.
- Enables warnings as errors in the VS Code testing workflow by adding a `pytest.ini` file, ensuring that new code is checked for warnings during development.
- Fixes warnings in tests related to relaxed constraints in DNS kernel development.
- Adds validation to the inputs of the `get_safe_power` function.