### PR TITLE
Added charged kernels calls via system state

### DIFF
--- a/docs/.assets/single_page_ref_generator.py
+++ b/docs/.assets/single_page_ref_generator.py
@@ -150,9 +150,7 @@ merge_markdown_files(
 
 # Theory
 filtered_paths = [
-    p
-    for p in source_paths_list
-    if "particula/docs/Theory/" in p.as_posix()
+    p for p in source_paths_list if "particula/docs/Theory/" in p.as_posix()
 ]
 
 # Generate folder structure, if needed

--- a/particula/dynamics/__init__.py
+++ b/particula/dynamics/__init__.py
@@ -67,6 +67,13 @@ from particula.dynamics.coagulation.charged_dimensionless_kernel import (
     get_coulomb_kernel_gopalakrishnan2012,
     get_coulomb_kernel_chahl2019,
 )
+from particula.dynamics.coagulation.charged_dimensional_kernel import (
+    get_hard_sphere_kernel_via_system_state,
+    get_coulomb_kernel_dyachkov2007_via_system_state,
+    get_coulomb_kernel_gatti2008_via_system_state,
+    get_coulomb_kernel_gopalakrishnan2012_via_system_state,
+    get_coulomb_kernel_chahl2019_via_system_state,
+)
 from particula.dynamics.coagulation.turbulent_shear_kernel import (
     get_turbulent_shear_kernel_st1956_via_system_state,
 )

--- a/particula/dynamics/coagulation/brownian_kernel.py
+++ b/particula/dynamics/coagulation/brownian_kernel.py
@@ -97,7 +97,7 @@ def get_brownian_kernel(
 
 def get_brownian_kernel_via_system_state(
     particle_radius: Union[float, NDArray[np.float64]],
-    mass_particle: Union[float, NDArray[np.float64]],
+    particle_mass: Union[float, NDArray[np.float64]],
     temperature: float,
     pressure: float,
     alpha_collision_efficiency: Union[float, NDArray[np.float64]] = 1.0,
@@ -119,7 +119,7 @@ def get_brownian_kernel_via_system_state(
 
     Arguments:
         - particle_radius : The radius of the particles [m].
-        - mass_particle : The mass of the particles [kg].
+        - particle_mass : The mass of the particles [kg].
         - temperature : The temperature of the air [K].
         - pressure : The pressure of the air [Pa].
         - alpha_collision_efficiency : The collision efficiency of the
@@ -157,7 +157,7 @@ def get_brownian_kernel_via_system_state(
 
     # get thermal speed
     mean_thermal_speed_particle = particles.get_mean_thermal_speed(
-        mass_particle, temperature
+        particle_mass, temperature
     )
 
     # get g collection term

--- a/particula/dynamics/coagulation/charged_dimensional_kernel.py
+++ b/particula/dynamics/coagulation/charged_dimensional_kernel.py
@@ -281,7 +281,7 @@ def get_coulomb_kernel_gatti2008_via_system_state(
         ``` py title="Example Usage"
         import particula as par
         kernel_gatti = (
-            par.dyanmics.get_coulomb_kernel_gatti2008_via_system_state(
+            par.dynamics.get_coulomb_kernel_gatti2008_via_system_state(
                 p_radius, p_mass, p_charge, 298.15, 101325
             )
         )

--- a/particula/dynamics/coagulation/charged_dimensional_kernel.py
+++ b/particula/dynamics/coagulation/charged_dimensional_kernel.py
@@ -1,6 +1,7 @@
 """
 Charged dimensional kernel for coagulation calculated from system state.
 """
+# pylint: disable=duplicate-code
 
 from typing import Union
 from numpy.typing import NDArray
@@ -161,7 +162,6 @@ def get_hard_sphere_kernel_via_system_state(
       Journal of Chemical Physics, 126(12).
       https://doi.org/10.1063/1.2713719
     """
-    # pylint: disable=duplicate-code
     # get system state properties
     (
         coulomb_potential_ratio,

--- a/particula/dynamics/coagulation/charged_dimensional_kernel.py
+++ b/particula/dynamics/coagulation/charged_dimensional_kernel.py
@@ -1,0 +1,178 @@
+"""
+Charged dimensional kernel for coagulation calculated from system state.
+"""
+
+from typing import Union
+from numpy.typing import NDArray
+import numpy as np
+
+
+from particula.gas import (
+    get_dynamic_viscosity,
+    get_molecule_mean_free_path,
+)
+from particula.particles import (
+    get_knudsen_number,
+    get_friction_factor,
+    get_cunningham_slip_correction,
+    get_coulomb_enhancement_ratio,
+    get_diffusive_knudsen_number,
+)
+from particula.util import get_reduced_self_broadcast
+from particula.dynamics.coagulation.charged_dimensionless_kernel import (
+    get_dimensional_kernel,
+    get_hard_sphere_kernel,
+    get_coulomb_kernel_dyachkov2007,
+    get_coulomb_kernel_gatti2008,
+    get_coulomb_kernel_gopalakrishnan2012,
+    get_coulomb_kernel_chahl2019,
+)
+
+
+def _system_state_properties(
+    particle_radius: Union[float, NDArray[np.float64]],
+    particle_mass: Union[float, NDArray[np.float64]],
+    particle_charge: Union[float, NDArray[np.float64]],
+    temperature: float,
+    pressure: float,
+) -> tuple[
+    NDArray[np.float64],
+    NDArray[np.float64],
+    NDArray[np.float64],
+    NDArray[np.float64],
+    NDArray[np.float64],
+]:
+    """
+    Get the system state properties for for charged particles.
+
+    Arguments:
+        - particle_radius : The radius of the particles [m].
+        - particle_mass : The mass of the particles [kg].
+        - particle_charge : The charge of the particles [C].
+        - temperature : The temperature of the system [K].
+        - pressure : The pressure of the system [Pa].
+
+    Returns:
+        - coulomb_potential_ratio : The Coulomb potential ratio
+            [dimensionless].
+        - diffusive_knudsen : The diffusive knudsen number [dimensionless].
+        - sum_of_radii : The sum of the radii of the particles [m].
+        - reduced_mass : The reduced mass of the particles [kg].
+        - reduced_friction_factor : The reduced friction factor of the
+            particles [dimensionless].
+    """
+
+    # get properties
+    dynamic_viscosity = get_dynamic_viscosity(temperature=temperature)
+
+    # get knudsen number
+    knudsen_number = get_knudsen_number(
+        mean_free_path=get_molecule_mean_free_path(
+            temperature=temperature,
+            dynamic_viscosity=dynamic_viscosity,
+            pressure=pressure,
+        ),
+        particle_radius=particle_radius,
+    )
+    # get friction factor
+    friction_factor = get_friction_factor(
+        particle_radius=particle_radius,
+        dynamic_viscosity=get_dynamic_viscosity(temperature=temperature),
+        slip_correction=get_cunningham_slip_correction(
+            knudsen_number=knudsen_number
+        ),
+    )
+
+    # get coulomb potential ratio
+    coulomb_potential_ratio = get_coulomb_enhancement_ratio(
+        particle_radius=particle_radius,
+        charge=particle_charge,
+        temperature=temperature,
+    )
+
+    # get diffusive knudsen number
+    diffusive_knudsen = get_diffusive_knudsen_number(
+        particle_radius=particle_radius,
+        particle_mass=particle_mass,
+        friction_factor=friction_factor,
+        coulomb_potential_ratio=coulomb_potential_ratio,
+        temperature=temperature,
+    )
+
+    sum_of_radii = (
+        particle_radius[:, np.newaxis] + particle_radius[np.newaxis, :]
+    )
+    reduced_mass = get_reduced_self_broadcast(particle_mass)
+    reduced_friction_factor = get_reduced_self_broadcast(friction_factor)
+
+    return (
+        coulomb_potential_ratio,
+        diffusive_knudsen,
+        sum_of_radii,
+        reduced_mass,
+        reduced_friction_factor,
+    )
+
+
+def get_hard_sphere_kernel_via_system_state(
+    particle_radius: Union[float, NDArray[np.float64]],
+    particle_mass: Union[float, NDArray[np.float64]],
+    particle_charge: Union[float, NDArray[np.float64]],
+    temperature: float,
+    pressure: float,
+) -> NDArray[np.float64]:
+    """
+    The hard sphere dimensioned coagulation kernel via system state.
+
+    For the hard sphere kernel, the required inputs diffusive knudsen number,
+    coulomb potential ratio, sum of radii, reduced mass...etc are all
+    calculated from the system state properties (temperature, pressure, etc.).
+    These are used to calculate the dimensionless kernel, which is then
+    converted to the dimensioned kernel.
+
+    Arguments:
+        - particle_radius : The radius of the particles [m].
+        - particle_mass : The mass of the particles [kg].
+        - particle_charge : The charge of the particles [C].
+        - temperature : The temperature of the system [K].
+        - pressure : The pressure of the system [Pa].
+
+    Returns:
+        - The dimensioned coagulation kernel, as a square matrix, of all
+            particle-particle interactions [m^3/s].
+
+    References:
+    - Dyachkov, S. A., Kustova, E. V., & Kustov, A. V. (2007). Coagulation of
+      particles in the transition regime: The effect of the Coulomb potential.
+      Journal of Chemical Physics, 126(12).
+      https://doi.org/10.1063/1.2713719
+    """
+    # pylint: disable=duplicate-code
+    # get system state properties
+    (
+        coulomb_potential_ratio,
+        diffusive_knudsen,
+        sum_of_radii,
+        reduced_mass,
+        reduced_friction_factor,
+    ) = _system_state_properties(
+        particle_radius=particle_radius,
+        particle_mass=particle_mass,
+        particle_charge=particle_charge,
+        temperature=temperature,
+        pressure=pressure,
+    )
+
+    # get dimensionless kernel
+    dimensionless_kernel = get_hard_sphere_kernel(
+        diffusive_knudsen=diffusive_knudsen,
+    )
+
+    # get dimensioned kernel
+    return get_dimensional_kernel(
+        dimensionless_kernel=dimensionless_kernel,
+        coulomb_potential_ratio=coulomb_potential_ratio,
+        sum_of_radii=sum_of_radii,
+        reduced_mass=reduced_mass,
+        reduced_friction_factor=reduced_friction_factor,
+    )

--- a/particula/dynamics/coagulation/charged_dimensional_kernel.py
+++ b/particula/dynamics/coagulation/charged_dimensional_kernel.py
@@ -43,7 +43,7 @@ def _system_state_properties(
     NDArray[np.float64],
 ]:
     """
-    Get the system state properties for for charged particles.
+    Get the system state properties for charged particles.
 
     Arguments:
         - particle_radius : The radius of the particles [m].
@@ -60,6 +60,8 @@ def _system_state_properties(
         - reduced_mass : The reduced mass of the particles [kg].
         - reduced_friction_factor : The reduced friction factor of the
             particles [dimensionless].
+
+    Examples: (This is an internal helper and typically not called directly.)
     """
 
     # get properties
@@ -74,6 +76,7 @@ def _system_state_properties(
         ),
         particle_radius=particle_radius,
     )
+
     # get friction factor
     friction_factor = get_friction_factor(
         particle_radius=particle_radius,
@@ -124,7 +127,10 @@ def get_hard_sphere_kernel_via_system_state(
     """
     The hard sphere dimensioned coagulation kernel via system state.
 
-    For the hard sphere kernel, the required inputs diffusive knudsen number,
+    For the hard sphere kernel, the dimensionless kernel is computed
+    internally based on the diffusive Knudsen number, then converted
+    to the dimensioned form using the system state properties
+    (particle radius, mass, charge, temperature, pressure).
     coulomb potential ratio, sum of radii, reduced mass...etc are all
     calculated from the system state properties (temperature, pressure, etc.).
     These are used to calculate the dimensionless kernel, which is then
@@ -140,6 +146,14 @@ def get_hard_sphere_kernel_via_system_state(
     Returns:
         - The dimensioned coagulation kernel, as a square matrix, of all
             particle-particle interactions [m^3/s].
+
+    Examples:
+        ``` py title="Example Usage"
+        kernel_matrix = get_hard_sphere_kernel_via_system_state(
+            p_radius, p_mass, p_charge, 298.15, 101325
+        )
+        # kernel_matrix is an N×N array of rates
+        ```
 
     References:
     - Dyachkov, S. A., Kustova, E. V., & Kustov, A. V. (2007). Coagulation of
@@ -169,6 +183,264 @@ def get_hard_sphere_kernel_via_system_state(
     )
 
     # get dimensioned kernel
+    return get_dimensional_kernel(
+        dimensionless_kernel=dimensionless_kernel,
+        coulomb_potential_ratio=coulomb_potential_ratio,
+        sum_of_radii=sum_of_radii,
+        reduced_mass=reduced_mass,
+        reduced_friction_factor=reduced_friction_factor,
+    )
+
+
+def get_coulomb_kernel_dyachkov2007_via_system_state(
+    particle_radius: Union[float, NDArray[np.float64]],
+    particle_mass: Union[float, NDArray[np.float64]],
+    particle_charge: Union[float, NDArray[np.float64]],
+    temperature: float,
+    pressure: float,
+) -> NDArray[np.float64]:
+    """
+    The dimensioned coagulation kernel via system state using Dyachkov (2007).
+
+    Arguments:
+        - particle_radius : The radius of the particles [m].
+        - particle_mass : The mass of the particles [kg].
+        - particle_charge : The charge of the particles [C].
+        - temperature : The temperature of the system [K].
+        - pressure : The pressure of the system [Pa].
+
+    Returns:
+        - The dimensioned coagulation kernel, as a square matrix,
+          [m^3/s].
+
+    Examples:
+        ``` py title="Example Usage"
+        import particula as par
+        kernel_dyachkov = (
+            par.dynamics.get_coulomb_kernel_dyachkov2007_via_system_state(
+                p_radius, p_mass, p_charge, 298.15, 101325
+            )
+        )
+        print(kernel_dyachkov.shape)
+        ```
+
+    References:
+    - Dyachkov, S. A., Kustova, E. V., & Kustov, A. V. (2007). Coagulation of
+      particles in the transition regime: The effect of the Coulomb potential.
+      Journal of Chemical Physics, 126(12).
+      https://doi.org/10.1063/1.2713719
+    """
+    (
+        coulomb_potential_ratio,
+        diffusive_knudsen,
+        sum_of_radii,
+        reduced_mass,
+        reduced_friction_factor,
+    ) = _system_state_properties(
+        particle_radius=particle_radius,
+        particle_mass=particle_mass,
+        particle_charge=particle_charge,
+        temperature=temperature,
+        pressure=pressure,
+    )
+    dimensionless_kernel = get_coulomb_kernel_dyachkov2007(
+        diffusive_knudsen=diffusive_knudsen,
+        coulomb_potential_ratio=coulomb_potential_ratio,
+    )
+    return get_dimensional_kernel(
+        dimensionless_kernel=dimensionless_kernel,
+        coulomb_potential_ratio=coulomb_potential_ratio,
+        sum_of_radii=sum_of_radii,
+        reduced_mass=reduced_mass,
+        reduced_friction_factor=reduced_friction_factor,
+    )
+
+
+def get_coulomb_kernel_gatti2008_via_system_state(
+    particle_radius: Union[float, NDArray[np.float64]],
+    particle_mass: Union[float, NDArray[np.float64]],
+    particle_charge: Union[float, NDArray[np.float64]],
+    temperature: float,
+    pressure: float,
+) -> NDArray[np.float64]:
+    """
+    The dimensioned coagulation kernel via system state using Gatti (2008).
+
+    Arguments:
+        - particle_radius : The radius of the particles [m].
+        - particle_mass : The mass of the particles [kg].
+        - particle_charge : The charge of the particles [C].
+        - temperature : The temperature of the system [K].
+        - pressure : The pressure of the system [Pa].
+
+    Returns:
+        - The dimensioned coagulation kernel, as a square matrix,
+          [m^3/s].
+
+    Examples:
+        ``` py title="Example Usage"
+        import particula as par
+        kernel_gatti = (
+            par.dyanmics.get_coulomb_kernel_gatti2008_via_system_state(
+                p_radius, p_mass, p_charge, 298.15, 101325
+            )
+        )
+        print(kernel_gatti)
+        ```
+
+    References:
+    - Gatti, M., & Kortshagen, U. (2008). Analytical model of particle
+      charging in plasmas over a wide range of collisionality. Physical Review
+      E - Statistical, Nonlinear, and Soft Matter Physics, 78(4).
+      https://doi.org/10.1103/PhysRevE.78.046402
+    """
+    (
+        coulomb_potential_ratio,
+        diffusive_knudsen,
+        sum_of_radii,
+        reduced_mass,
+        reduced_friction_factor,
+    ) = _system_state_properties(
+        particle_radius=particle_radius,
+        particle_mass=particle_mass,
+        particle_charge=particle_charge,
+        temperature=temperature,
+        pressure=pressure,
+    )
+    dimensionless_kernel = get_coulomb_kernel_gatti2008(
+        diffusive_knudsen=diffusive_knudsen,
+        coulomb_potential_ratio=coulomb_potential_ratio,
+    )
+    return get_dimensional_kernel(
+        dimensionless_kernel=dimensionless_kernel,
+        coulomb_potential_ratio=coulomb_potential_ratio,
+        sum_of_radii=sum_of_radii,
+        reduced_mass=reduced_mass,
+        reduced_friction_factor=reduced_friction_factor,
+    )
+
+
+def get_coulomb_kernel_gopalakrishnan2012_via_system_state(
+    particle_radius: Union[float, NDArray[np.float64]],
+    particle_mass: Union[float, NDArray[np.float64]],
+    particle_charge: Union[float, NDArray[np.float64]],
+    temperature: float,
+    pressure: float,
+) -> NDArray[np.float64]:
+    """
+    The dimensioned coagulation kernel via system state
+    using Gopalakrishnan (2012).
+
+    Arguments:
+        - particle_radius : The radius of the particles [m].
+        - particle_mass : The mass of the particles [kg].
+        - particle_charge : The charge of the particles [C].
+        - temperature : The temperature of the system [K].
+        - pressure : The pressure of the system [Pa].
+
+    Returns:
+        - The dimensioned coagulation kernel, as a square matrix,
+          [m^3/s].
+
+    Examples:
+        ``` py title="Example Usage"
+        import particula as par
+        kernel_gopal = (
+            par.dyanmics.get_coulomb_kernel_gopalakrishnan2012_via_system_state(
+                p_radius, p_mass, p_charge, 298.15, 101325
+            )
+        )
+        # kernel_gopal is an N×N matrix [m^3/s]
+        ```
+
+    References:
+    - Gopalakrishnan, R., & Hogan, C. J. (2012). Coulomb-influenced collisions
+      in aerosols and dusty plasmas. Physical Review E - Statistical, Nonlinear
+      and Soft Matter Physics, 85(2).
+      https://doi.org/10.1103/PhysRevE.85.026410
+    """
+    (
+        coulomb_potential_ratio,
+        diffusive_knudsen,
+        sum_of_radii,
+        reduced_mass,
+        reduced_friction_factor,
+    ) = _system_state_properties(
+        particle_radius=particle_radius,
+        particle_mass=particle_mass,
+        particle_charge=particle_charge,
+        temperature=temperature,
+        pressure=pressure,
+    )
+    dimensionless_kernel = get_coulomb_kernel_gopalakrishnan2012(
+        diffusive_knudsen=diffusive_knudsen,
+        coulomb_potential_ratio=coulomb_potential_ratio,
+    )
+    return get_dimensional_kernel(
+        dimensionless_kernel=dimensionless_kernel,
+        coulomb_potential_ratio=coulomb_potential_ratio,
+        sum_of_radii=sum_of_radii,
+        reduced_mass=reduced_mass,
+        reduced_friction_factor=reduced_friction_factor,
+    )
+
+
+def get_coulomb_kernel_chahl2019_via_system_state(
+    particle_radius: Union[float, NDArray[np.float64]],
+    particle_mass: Union[float, NDArray[np.float64]],
+    particle_charge: Union[float, NDArray[np.float64]],
+    temperature: float,
+    pressure: float,
+) -> NDArray[np.float64]:
+    """
+    The dimensioned coagulation kernel via system state
+    using Chahl (2019).
+
+    Arguments:
+        - particle_radius : The radius of the particles [m].
+        - particle_mass : The mass of the particles [kg].
+        - particle_charge : The charge of the particles [C].
+        - temperature : The temperature of the system [K].
+        - pressure : The pressure of the system [Pa].
+
+    Returns:
+        - The dimensioned coagulation kernel, as a square matrix,
+          [m^3/s].
+
+    Examples:
+        ``` py title="Example Usage"
+        import particula as par
+        kernel_chahl = ()
+            par.dynamics.get_coulomb_kernel_chahl2019_via_system_state(
+            p_radius, p_mass, p_charge, 298.15, 101325
+            )
+        )
+        print(kernel_chahl)
+        ```
+
+    References:
+    - Chahl, H. S., & Gopalakrishnan, R. (2019). High potential, near free
+        molecular regime Coulombic collisions in aerosols and dusty plasmas.
+        Aerosol Science and Technology, 53(8), 933-957.
+        https://doi.org/10.1080/02786826.2019.1614522
+    """
+    (
+        coulomb_potential_ratio,
+        diffusive_knudsen,
+        sum_of_radii,
+        reduced_mass,
+        reduced_friction_factor,
+    ) = _system_state_properties(
+        particle_radius=particle_radius,
+        particle_mass=particle_mass,
+        particle_charge=particle_charge,
+        temperature=temperature,
+        pressure=pressure,
+    )
+    dimensionless_kernel = get_coulomb_kernel_chahl2019(
+        diffusive_knudsen=diffusive_knudsen,
+        coulomb_potential_ratio=coulomb_potential_ratio,
+    )
     return get_dimensional_kernel(
         dimensionless_kernel=dimensionless_kernel,
         coulomb_potential_ratio=coulomb_potential_ratio,

--- a/particula/dynamics/coagulation/charged_dimensionless_kernel.py
+++ b/particula/dynamics/coagulation/charged_dimensionless_kernel.py
@@ -1,4 +1,6 @@
-"""Dimensionless coagulation for several approximations of the transition regime."""
+"""
+Dimensionless coagulation for several approximations of the transition regime.
+"""
 
 from typing import Union
 from numpy.typing import NDArray

--- a/particula/dynamics/coagulation/charged_dimensionless_kernel.py
+++ b/particula/dynamics/coagulation/charged_dimensionless_kernel.py
@@ -262,10 +262,16 @@ def get_coulomb_kernel_gopalakrishnan2012(
 
     References:
     - Gopalakrishnan, R., & Hogan, C. J. (2012). Coulomb-influenced collisions
-      in aerosols and dusty plasmas. Physical Review E - Statistical, Nonlinear,
+      in aerosols and dusty plasmas. Physical Review E - Statistical, Nonlinear
       and Soft Matter Physics, 85(2).
       https://doi.org/10.1103/PhysRevE.85.026410
     """
+    # Condition for the transition regime
+    bool_mask = coulomb_potential_ratio > 0.5
+    # Ensure no division by zero
+    coulomb_potential_ratio = np.maximum(coulomb_potential_ratio, 1e-12)
+
+    # Calculate the continuum limit
     continuum_limit = 4 * np.pi * diffusive_knudsen**2
     min_fxn = np.minimum(
         diffusive_knudsen,
@@ -274,9 +280,9 @@ def get_coulomb_kernel_gopalakrishnan2012(
     # Ensure min_fxn does not contain invalid values
     min_fxn = np.maximum(min_fxn, 1e-16)
     # Condition for the transition regime
-    condition = (coulomb_potential_ratio > 0.5) & (min_fxn < 2.5)
+    condition = min_fxn < 2.5
     return np.where(
-        condition,
+        condition & bool_mask,
         continuum_limit / (1 + 1.598 * min_fxn**1.1709),
         get_hard_sphere_kernel(diffusive_knudsen),
     )

--- a/particula/dynamics/coagulation/coagulation_strategy/brownian_coagulation_strategy.py
+++ b/particula/dynamics/coagulation/coagulation_strategy/brownian_coagulation_strategy.py
@@ -68,7 +68,7 @@ class BrownianCoagulationStrategy(CoagulationStrategyABC):
 
         return get_brownian_kernel_via_system_state(
             particle_radius=particle.get_radius(),
-            mass_particle=particle.get_mass(),
+            particle_mass=particle.get_mass(),
             temperature=temperature,
             pressure=pressure,
         )

--- a/particula/dynamics/coagulation/tests/brownian_kernel_test.py
+++ b/particula/dynamics/coagulation/tests/brownian_kernel_test.py
@@ -239,7 +239,7 @@ def test_brownian_coagulation_kernel_via_system_state_input_validation():
     with pytest.raises(TypeError):
         brownian_kernel.get_brownian_kernel_via_system_state(
             particle_radius="not a number",
-            mass_particle="not a number",
+            particle_mass="not a number",
             temperature="not a number",
             pressure="not a number",
             alpha_collision_efficiency="not a number",

--- a/particula/dynamics/coagulation/tests/charge_dimensional_kernel_test.py
+++ b/particula/dynamics/coagulation/tests/charge_dimensional_kernel_test.py
@@ -25,6 +25,10 @@ from particula.dynamics.coagulation.charged_dimensional_kernel import (
     ],
 )
 def test_dimensioned_coagulation_kernels_array(kernel_function):
+    """
+    Test the coagulation kernels for charged particles with
+    calls via system state.
+    """
     radii = np.array([1e-9, 2e-9, 5e-9])*10
     mass = np.array([1e-18, 2e-18, 5e-18])
     charge = np.array([-1, 0, 1])

--- a/particula/dynamics/coagulation/tests/charge_dimensional_kernel_test.py
+++ b/particula/dynamics/coagulation/tests/charge_dimensional_kernel_test.py
@@ -1,0 +1,36 @@
+"""
+Test the coagulation kernels for charged particles with calls
+via system state.
+"""
+
+import numpy as np
+import pytest
+from particula.dynamics.coagulation.charged_dimensional_kernel import (
+    get_hard_sphere_kernel_via_system_state,
+    get_coulomb_kernel_dyachkov2007_via_system_state,
+    get_coulomb_kernel_gatti2008_via_system_state,
+    get_coulomb_kernel_gopalakrishnan2012_via_system_state,
+    get_coulomb_kernel_chahl2019_via_system_state,
+)
+
+
+@pytest.mark.parametrize(
+    "kernel_function",
+    [
+        get_hard_sphere_kernel_via_system_state,
+        get_coulomb_kernel_dyachkov2007_via_system_state,
+        get_coulomb_kernel_gatti2008_via_system_state,
+        get_coulomb_kernel_gopalakrishnan2012_via_system_state,
+        get_coulomb_kernel_chahl2019_via_system_state,
+    ],
+)
+def test_dimensioned_coagulation_kernels_array(kernel_function):
+    radii = np.array([1e-9, 2e-9, 5e-9])*10
+    mass = np.array([1e-18, 2e-18, 5e-18])
+    charge = np.array([-1, 0, 1])
+    temperature = 300.0
+    pressure = 101325.0
+
+    kernel_matrix = kernel_function(radii, mass, charge, temperature, pressure)
+    assert kernel_matrix.shape == (3, 3)
+    assert np.all(np.isfinite(kernel_matrix))


### PR DESCRIPTION
Added get_coulomb_kernel_chahl2019_via_system_state calls to match the other kernels that have that _via_system_state option.
Added tests for all.
Added them to the dynamics init file

Also updated get_coulomb_kernel_gopalakrishnan2012, so it can handle zeros in charge.
Fixes #646 

## Summary by Sourcery

Adds charged kernels calls via system state to match the other kernels that have that _via_system_state option, and updates get_coulomb_kernel_gopalakrishnan2012 to handle zeros in charge.

New Features:
- Adds get_coulomb_kernel_chahl2019_via_system_state calls to match the other kernels that have that _via_system_state option.
- Adds charged dimensional kernel for coagulation calculated from system state.

Tests:
- Adds tests for all the new coulomb kernels.

## Summary by Sourcery

Adds the `get_coulomb_kernel_chahl2019_via_system_state` function to calculate the charged kernel using the Chahl (2019) method via system state, mirroring the functionality of other kernel methods. Also, updates the `get_coulomb_kernel_gopalakrishnan2012` function to handle zero values in charge calculations.

New Features:
- Adds `get_coulomb_kernel_chahl2019_via_system_state` to calculate the charged kernel using the Chahl (2019) method via system state, similar to other kernel methods.

Tests:
- Adds tests for the new `get_coulomb_kernel_chahl2019_via_system_state` function and other related functions to ensure correct behavior.