### PR TITLE
In examples update mass_particle to particle_mass

### DIFF
--- a/docs/Examples/Chamber_Wall_Loss/Notebooks/Chamber_Forward_Simulation.ipynb
+++ b/docs/Examples/Chamber_Wall_Loss/Notebooks/Chamber_Forward_Simulation.ipynb
@@ -111,7 +111,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -128,13 +128,13 @@
    "source": [
     "# coagulation rate\n",
     "\n",
-    "mass_particle = (\n",
+    "particle_mass = (\n",
     "    4 / 3 * np.pi * radius_bins**3 * 1000\n",
     ")  # mass of the particles in kg\n",
     "\n",
     "kernel = par.dynamics.get_brownian_kernel_via_system_state(\n",
     "    particle_radius=radius_bins,\n",
-    "    mass_particle=mass_particle,\n",
+    "    particle_mass=particle_mass,\n",
     "    temperature=293.15,\n",
     "    pressure=101325,\n",
     "    alpha_collision_efficiency=1,\n",
@@ -214,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -241,7 +241,7 @@
     "\n",
     "kernel = par.dynamics.get_brownian_kernel_via_system_state(\n",
     "    particle_radius=radius_bins,\n",
-    "    mass_particle=mass_particle,\n",
+    "    particle_mass=particle_mass,\n",
     "    temperature=293.15,\n",
     "    pressure=101325,\n",
     "    alpha_collision_efficiency=1,\n",

--- a/docs/Examples/Dynamics/Coagulation/Functional/Coagulation_Basic_1_PMF.ipynb
+++ b/docs/Examples/Dynamics/Coagulation/Functional/Coagulation_Basic_1_PMF.ipynb
@@ -116,7 +116,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -397,7 +397,7 @@
     "# to compute the coagulation rates between particles of different sizes.\n",
     "kernel = par.dynamics.get_brownian_kernel_via_system_state(\n",
     "    particle_radius=radius_bins,\n",
-    "    mass_particle=mass_bins,\n",
+    "    particle_mass=mass_bins,\n",
     "    temperature=293.15,  # Temperature in Kelvin (20°C)\n",
     "    pressure=101325,  # Pressure in Pascals (1 atm)\n",
     "    alpha_collision_efficiency=1.0,  # Assume perfect collision efficiency\n",
@@ -1329,7 +1329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1341,7 +1341,7 @@
     "# Calculate the coagulation kernel\n",
     "kernel = par.dynamics.get_brownian_kernel_via_system_state(\n",
     "    particle_radius=radius_bins,\n",
-    "    mass_particle=mass_bins,\n",
+    "    particle_mass=mass_bins,\n",
     "    temperature=293.15,  # Temperature in Kelvin\n",
     "    pressure=101325,  # Pressure in Pascals (1 atm)\n",
     "    alpha_collision_efficiency=1.0,  # Assume perfect collision efficiency\n",

--- a/docs/Examples/Dynamics/Coagulation/Functional/Coagulation_Basic_2_PDF.ipynb
+++ b/docs/Examples/Dynamics/Coagulation/Functional/Coagulation_Basic_2_PDF.ipynb
@@ -89,7 +89,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -5351,7 +5351,7 @@
     "# to compute the coagulation rates between particles of different sizes.\n",
     "kernel = par.dynamics.get_brownian_kernel_via_system_state(\n",
     "    particle_radius=radius_bins,\n",
-    "    mass_particle=mass_bins,\n",
+    "    particle_mass=mass_bins,\n",
     "    temperature=293.15,  # Temperature in Kelvin (20°C)\n",
     "    pressure=101325,  # Pressure in Pascals (1 atm)\n",
     "    alpha_collision_efficiency=1.0,  # Assume perfect collision efficiency\n",
@@ -5481,7 +5481,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -5493,7 +5493,7 @@
     "# Calculate the coagulation kernel\n",
     "kernel = par.dynamics.get_brownian_kernel_via_system_state(\n",
     "    particle_radius=radius_bins,\n",
-    "    mass_particle=mass_bins,\n",
+    "    particle_mass=mass_bins,\n",
     "    temperature=293.15,  # Temperature in Kelvin\n",
     "    pressure=101325,  # Pressure in Pascals (1 atm)\n",
     "    alpha_collision_efficiency=1.0,  # Assume perfect collision efficiency\n",

--- a/docs/Examples/Dynamics/Coagulation/Functional/Coagulation_Basic_3_compared.ipynb
+++ b/docs/Examples/Dynamics/Coagulation/Functional/Coagulation_Basic_3_compared.ipynb
@@ -362,7 +362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -372,7 +372,7 @@
     "# Calculate the Brownian coagulation kernel matrix\n",
     "kernel = par.dynamics.get_brownian_kernel_via_system_state(\n",
     "    particle_radius=radius_bins,\n",
-    "    mass_particle=mass_bins,\n",
+    "    particle_mass=mass_bins,\n",
     "    temperature=293.15,  # Temperature in Kelvin (20°C)\n",
     "    pressure=101325,  # Pressure in Pascals (1 atm)\n",
     "    alpha_collision_efficiency=1.0,  # Assume perfect collision efficiency\n",

--- a/docs/Examples/Dynamics/Coagulation/Functional/Coagulation_Basic_4_ParticleResolved.ipynb
+++ b/docs/Examples/Dynamics/Coagulation/Functional/Coagulation_Basic_4_ParticleResolved.ipynb
@@ -68,7 +68,7 @@
     "\n",
     "kernel = par.dynamics.get_brownian_kernel_via_system_state(\n",
     "    particle_radius=radius_bins,\n",
-    "    mass_particle=mass_bins,\n",
+    "    particle_mass=mass_bins,\n",
     "    temperature=298.15,\n",
     "    pressure=101325,\n",
     ")  # Calculate the Brownian coagulation kernel for the radius bins\n",

--- a/particula/dynamics/coagulation/tests/brownian_kernel_test.py
+++ b/particula/dynamics/coagulation/tests/brownian_kernel_test.py
@@ -200,7 +200,7 @@ def test_brownian_coagulation_kernel_via_system_state_basic():
     """
     # diameters, 2 nm, 1 um, 20 um
     particle_radius = np.array([1e-9, 5e-7, 10e-6])  # radii in meters
-    mass_particle = 4 / 3 * np.pi * particle_radius**3 * 1000  # mass in kg
+    particle_mass = 4 / 3 * np.pi * particle_radius**3 * 1000  # mass in kg
     temperature = 298  # temperature in Kelvin
     pressure = 101325  # pressure in Pascal
     alpha_collision_efficiency = np.array([1.0, 1.0, 1.0])  # dimensionless
@@ -221,7 +221,7 @@ def test_brownian_coagulation_kernel_via_system_state_basic():
     # Call the system function
     result = brownian_kernel.get_brownian_kernel_via_system_state(
         particle_radius,
-        mass_particle,
+        particle_mass,
         temperature,
         pressure,
         alpha_collision_efficiency,

--- a/particula/particles/properties/tests/diffusive_knudsen_test.py
+++ b/particula/particles/properties/tests/diffusive_knudsen_test.py
@@ -10,14 +10,14 @@ from particula.particles.properties.diffusive_knudsen_module import (
 def test_diffusive_knudsen_number_scalar():
     """Test the diffusive Knudsen number calculation with scalar inputs."""
     radius = 100e-9  # meters
-    mass_particle = 1e-24  # kg
+    particle_mass = 1e-24  # kg
     friction_factor = 1.0  # dimensionless
     coulomb_potential_ratio = 0.5  # dimensionless
     temperature = 298.15  # K
 
     result = get_diffusive_knudsen_number(
         radius,
-        mass_particle,
+        particle_mass,
         friction_factor,
         coulomb_potential_ratio,
         temperature,
@@ -30,14 +30,14 @@ def test_diffusive_knudsen_number_scalar():
 def test_diffusive_knudsen_number_array():
     """Test the diffusive Knudsen number calculation with array inputs."""
     radius = np.array([100e-9, 1e-6])
-    mass_particle = np.array([1e-24, 2e-20])
+    particle_mass = np.array([1e-24, 2e-20])
     friction_factor = np.array([1.0, 1.5])
     coulomb_potential_ratio = np.array([0.5, 0])  # different charges
     temperature = 298.15
 
     result = get_diffusive_knudsen_number(
         radius,
-        mass_particle,
+        particle_mass,
         friction_factor,
         coulomb_potential_ratio,
         temperature,
@@ -53,14 +53,14 @@ def test_with_zero_coulomb_potential_ratio():
     """Test the diffusive Knudsen number calculation with zero Coulomb
     potential ratio."""
     radius = 0.1
-    mass_particle = 1e-18
+    particle_mass = 1e-18
     friction_factor = 1.0
     coulomb_potential_ratio = 0.0  # no charges
     temperature = 298.15
 
     result = get_diffusive_knudsen_number(
         radius,
-        mass_particle,
+        particle_mass,
         friction_factor,
         coulomb_potential_ratio,
         temperature,


### PR DESCRIPTION
follow up from #664 PR comments

## Summary by Sourcery

Rename the variable 'mass_particle' to 'particle_mass' for clarity and consistency across the codebase.