### PR TITLE
Correct function names in mass_transfer.py

### DIFF
--- a/particula/dynamics/__init__.py
+++ b/particula/dynamics/__init__.py
@@ -34,10 +34,12 @@ from particula.dynamics.condensation.condensation_strategies import (
     CondensationIsothermal,
 )
 from particula.dynamics.condensation.mass_transfer import (
-    mass_transfer_rate,
-    first_order_mass_transport_k,
-    radius_transfer_rate,
-    calculate_mass_transfer,
+    get_mass_transfer_rate,
+    get_first_order_mass_transport_k,
+    get_radius_transfer_rate,
+    get_mass_transfer,
+    get_mass_transfer_of_single_species,
+    get_mass_transfer_of_multiple_species,
 )
 
 # particula.dynamics.coagulation

--- a/particula/dynamics/condensation/condensation_strategies.py
+++ b/particula/dynamics/condensation/condensation_strategies.py
@@ -226,7 +226,7 @@ class CondensationStrategy(ABC):
             mass_accommodation=self.accommodation_coefficient,
         )
         return get_first_order_mass_transport_k(
-            radius=radius,
+            particle_radius=radius,
             vapor_transition=vapor_transition,
             diffusion_coefficient=self.diffusion_coefficient,
         )

--- a/particula/dynamics/condensation/condensation_strategies.py
+++ b/particula/dynamics/condensation/condensation_strategies.py
@@ -51,9 +51,9 @@ from particula.particles import (
 )
 from particula.gas import get_molecule_mean_free_path
 from particula.dynamics.condensation.mass_transfer import (
-    first_order_mass_transport_k,
-    mass_transfer_rate,
-    calculate_mass_transfer,
+    get_first_order_mass_transport_k,
+    get_mass_transfer_rate,
+    get_mass_transfer,
 )
 
 logger = logging.getLogger("particula")
@@ -225,7 +225,7 @@ class CondensationStrategy(ABC):
             ),
             mass_accommodation=self.accommodation_coefficient,
         )
-        return first_order_mass_transport_k(
+        return get_first_order_mass_transport_k(
             radius=radius,
             vapor_transition=vapor_transition,
             diffusion_coefficient=self.diffusion_coefficient,
@@ -485,7 +485,7 @@ class CondensationIsothermal(CondensationStrategy):
         pressure_delta = self.calculate_pressure_delta(
             particle, gas_species, temperature, radius_with_fill
         )
-        return mass_transfer_rate(
+        return get_mass_transfer_rate(
             pressure_delta=pressure_delta,
             first_order_mass_transport=first_order_mass_transport,
             temperature=temperature,
@@ -538,7 +538,7 @@ class CondensationIsothermal(CondensationStrategy):
             pressure=pressure,
         )
         # calculate the mass gain or loss per bin
-        mass_transfer = calculate_mass_transfer(
+        mass_transfer = get_mass_transfer(
             mass_rate=mass_rate,  # type: ignore
             time_step=time_step,
             gas_mass=gas_species.get_concentration(),  # type: ignore

--- a/particula/dynamics/condensation/condensation_strategies.py
+++ b/particula/dynamics/condensation/condensation_strategies.py
@@ -188,7 +188,7 @@ class CondensationStrategy(ABC):
 
     def first_order_mass_transport(
         self,
-        radius: Union[float, NDArray[np.float64]],
+        particle_radius: Union[float, NDArray[np.float64]],
         temperature: float,
         pressure: float,
         dynamic_viscosity: Optional[float] = None,
@@ -218,7 +218,7 @@ class CondensationStrategy(ABC):
         """
         vapor_transition = get_vapor_transition_correction(
             knudsen_number=self.knudsen_number(
-                radius=radius,
+                radius=particle_radius,
                 temperature=temperature,
                 pressure=pressure,
                 dynamic_viscosity=dynamic_viscosity,
@@ -226,7 +226,7 @@ class CondensationStrategy(ABC):
             mass_accommodation=self.accommodation_coefficient,
         )
         return get_first_order_mass_transport_k(
-            particle_radius=radius,
+            particle_radius=particle_radius,
             vapor_transition=vapor_transition,
             diffusion_coefficient=self.diffusion_coefficient,
         )
@@ -477,7 +477,7 @@ class CondensationIsothermal(CondensationStrategy):
 
         radius_with_fill = self._fill_zero_radius(particle.get_radius())
         first_order_mass_transport = self.first_order_mass_transport(
-            radius=radius_with_fill,
+            particle_radius=radius_with_fill,
             temperature=temperature,
             pressure=pressure,
             dynamic_viscosity=dynamic_viscosity,

--- a/particula/dynamics/condensation/mass_transfer.py
+++ b/particula/dynamics/condensation/mass_transfer.py
@@ -34,11 +34,11 @@ from particula.util.validate_inputs import validate_inputs
 
 @validate_inputs(
     {
-        "radius": "nonnegative",
+        "particle_radius": "nonnegative",
     }
 )
 def get_first_order_mass_transport_k(
-    radius: Union[float, NDArray[np.float64]],
+    particle_radius: Union[float, NDArray[np.float64]],
     vapor_transition: Union[float, NDArray[np.float64]],
     diffusion_coefficient: Union[float, NDArray[np.float64]] = 2e-5,
 ) -> Union[float, NDArray[np.float64]]:
@@ -55,7 +55,7 @@ def get_first_order_mass_transport_k(
         - X : Vapor transition correction factor [unitless].
 
     Arguments:
-        - radius : The radius of the particle [m].
+        - particle_radius : The radius of the particle [m].
         - vapor_transition : The vapor transition correction factor [unitless].
         - diffusion_coefficient : The diffusion coefficient of the vapor [m²/s].
           Defaults to 2e-5 (approx. air).
@@ -94,8 +94,10 @@ def get_first_order_mass_transport_k(
         and vapor_transition.dtype == np.float64
         and vapor_transition.ndim == 2
     ):  # extent radius
-        radius = radius[:, np.newaxis]  # type: ignore
-    return 4 * np.pi * radius * diffusion_coefficient * vapor_transition  # type: ignore
+        particle_radius = particle_radius[:, np.newaxis]  # type: ignore
+    return (
+        4 * np.pi * particle_radius * diffusion_coefficient * vapor_transition
+    )
 
 
 @validate_inputs(
@@ -174,11 +176,15 @@ def get_mass_transfer_rate(
 
 
 @validate_inputs(
-    {"mass_rate": "finite", "radius": "nonnegative", "density": "positive"}
+    {
+        "mass_rate": "finite",
+        "particle_radius": "nonnegative",
+        "density": "positive",
+    }
 )
 def get_radius_transfer_rate(
     mass_rate: Union[float, NDArray[np.float64]],
-    radius: Union[float, NDArray[np.float64]],
+    particle_radius: Union[float, NDArray[np.float64]],
     density: Union[float, NDArray[np.float64]],
 ) -> Union[float, NDArray[np.float64]]:
     """
@@ -195,7 +201,7 @@ def get_radius_transfer_rate(
 
     Arguments:
         - mass_rate : The mass transfer rate [kg/s].
-        - radius : The radius of the particle [m].
+        - particle_radius : The radius of the particle [m].
         - density : The density of the particle [kg/m³].
 
     Returns:
@@ -206,7 +212,7 @@ def get_radius_transfer_rate(
         import particula as par
         par.dynamics.radius_transfer_rate(
             mass_rate=1e-21,
-            radius=1e-6,
+            particle_radius=1e-6,
             density=1000
         )
         # Output: 7.95774715e-14
@@ -216,15 +222,15 @@ def get_radius_transfer_rate(
         import particula as par
         par.dynamics.radius_transfer_rate(
             mass_rate=np.array([1e-21, 2e-21]),
-            radius=np.array([1e-6, 2e-6]),
+            particle_radius=np.array([1e-6, 2e-6]),
             density=1000
         )
         # Output: array([7.95774715e-14, 1.98943679e-14])
         ```
     """
     if isinstance(mass_rate, np.ndarray) and mass_rate.ndim == 2:
-        radius = radius[:, np.newaxis]  # type: ignore
-    return mass_rate / (density * 4 * np.pi * radius**2)  # type: ignore
+        particle_radius = particle_radius[:, np.newaxis]
+    return mass_rate / (density * 4 * np.pi * particle_radius**2)
 
 
 @validate_inputs(

--- a/particula/dynamics/condensation/mass_transfer.py
+++ b/particula/dynamics/condensation/mass_transfer.py
@@ -67,7 +67,7 @@ def get_first_order_mass_transport_k(
         ```py title="Float input"
         import particula as par
         par.dynamics.get_first_order_mass_transport_k(
-            radius=1e-6,
+            particle_radius=1e-6,
             vapor_transition=0.6,
             diffusion_coefficient=2e-9
         )
@@ -77,7 +77,7 @@ def get_first_order_mass_transport_k(
         ```py title="Array input"
         import particula as par
         par.dynamics.get_first_order_mass_transport_k(
-            radius=np.array([1e-6, 2e-6]),
+            particle_radius=np.array([1e-6, 2e-6]),
             vapor_transition=np.array([0.6, 0.6]),
             diffusion_coefficient=2e-9
         )

--- a/particula/dynamics/condensation/mass_transfer.py
+++ b/particula/dynamics/condensation/mass_transfer.py
@@ -37,7 +37,7 @@ from particula.util.validate_inputs import validate_inputs
         "radius": "nonnegative",
     }
 )
-def first_order_mass_transport_k(
+def get_first_order_mass_transport_k(
     radius: Union[float, NDArray[np.float64]],
     vapor_transition: Union[float, NDArray[np.float64]],
     diffusion_coefficient: Union[float, NDArray[np.float64]] = 2e-5,
@@ -65,7 +65,8 @@ def first_order_mass_transport_k(
 
     Examples:
         ```py title="Float input"
-        first_order_mass_transport_k(
+        import particula as par
+        par.dynamics.get_first_order_mass_transport_k(
             radius=1e-6,
             vapor_transition=0.6,
             diffusion_coefficient=2e-9
@@ -74,7 +75,8 @@ def first_order_mass_transport_k(
         ```
 
         ```py title="Array input"
-        first_order_mass_transport_k(
+        import particula as par
+        par.dynamics.get_first_order_mass_transport_k(
             radius=np.array([1e-6, 2e-6]),
             vapor_transition=np.array([0.6, 0.6]),
             diffusion_coefficient=2e-9
@@ -104,7 +106,7 @@ def first_order_mass_transport_k(
         "molar_mass": "positive",
     }
 )
-def mass_transfer_rate(
+def get_mass_transfer_rate(
     pressure_delta: Union[float, NDArray[np.float64]],
     first_order_mass_transport: Union[float, NDArray[np.float64]],
     temperature: Union[float, NDArray[np.float64]],
@@ -136,7 +138,8 @@ def mass_transfer_rate(
 
     Examples:
         ```py title="Single value input"
-        mass_transfer_rate(
+        import particula as par
+        par.dynamics.mass_transfer_rate(
             pressure_delta=10.0,
             first_order_mass_transport=1e-17,
             temperature=300.0,
@@ -146,7 +149,8 @@ def mass_transfer_rate(
         ```
 
         ```py title="Array input"
-        mass_transfer_rate(
+        import particula as par
+        par.dynamics.mass_transfer_rate(
             pressure_delta=np.array([10.0, 15.0]),
             first_order_mass_transport=np.array([1e-17, 2e-17]),
             temperature=300.0,
@@ -172,7 +176,7 @@ def mass_transfer_rate(
 @validate_inputs(
     {"mass_rate": "finite", "radius": "nonnegative", "density": "positive"}
 )
-def radius_transfer_rate(
+def get_radius_transfer_rate(
     mass_rate: Union[float, NDArray[np.float64]],
     radius: Union[float, NDArray[np.float64]],
     density: Union[float, NDArray[np.float64]],
@@ -199,7 +203,8 @@ def radius_transfer_rate(
 
     Examples:
         ```py title="Single value input"
-        radius_transfer_rate(
+        import particula as par
+        par.dynamics.radius_transfer_rate(
             mass_rate=1e-21,
             radius=1e-6,
             density=1000
@@ -208,7 +213,8 @@ def radius_transfer_rate(
         ```
 
         ```py title="Array input"
-        radius_transfer_rate(
+        import particula as par
+        par.dynamics.radius_transfer_rate(
             mass_rate=np.array([1e-21, 2e-21]),
             radius=np.array([1e-6, 2e-6]),
             density=1000
@@ -230,7 +236,7 @@ def radius_transfer_rate(
         "particle_concentration": "nonnegative",
     }
 )
-def calculate_mass_transfer(
+def get_mass_transfer(
     mass_rate: NDArray[np.float64],
     time_step: float,
     gas_mass: NDArray[np.float64],
@@ -259,7 +265,8 @@ def calculate_mass_transfer(
 
     Examples:
         ```py title="Single species input"
-        calculate_mass_transfer(
+        import particula as par
+        par.dynamics.get_mass_transfer(
             mass_rate=np.array([0.1, 0.5]),
             time_step=10,
             gas_mass=np.array([0.5]),
@@ -269,7 +276,8 @@ def calculate_mass_transfer(
         ```
 
         ```py title="Multiple species input"
-        calculate_mass_transfer(
+        import particula as par
+        par.dynamics.get_mass_transfer(
             mass_rate=np.array([[0.1, 0.05, 0.03], [0.2, 0.15, 0.07]]),
             time_step=10,
             gas_mass=np.array([1.0, 0.8, 0.5]),
@@ -279,7 +287,7 @@ def calculate_mass_transfer(
         ```
     """
     if gas_mass.size == 1:  # Single species case
-        return calculate_mass_transfer_single_species(
+        return get_mass_transfer_of_single_species(
             mass_rate,
             time_step,
             gas_mass,
@@ -287,7 +295,7 @@ def calculate_mass_transfer(
             particle_concentration,
         )
     # Multiple species case
-    return calculate_mass_transfer_multiple_species(
+    return get_mass_transfer_of_multiple_species(
         mass_rate,
         time_step,
         gas_mass,
@@ -305,7 +313,7 @@ def calculate_mass_transfer(
         "particle_concentration": "nonnegative",
     }
 )
-def calculate_mass_transfer_single_species(
+def get_mass_transfer_of_single_species(
     mass_rate: NDArray[np.float64],
     time_step: float,
     gas_mass: NDArray[np.float64],
@@ -336,7 +344,8 @@ def calculate_mass_transfer_single_species(
 
     Examples:
         ```py title="Single species input"
-        calculate_mass_transfer_single_species(
+        import particula as par
+        par.dynamics.get_mass_transfer_of_single_species(
             mass_rate=np.array([0.1, 0.5]),
             time_step=10,
             gas_mass=np.array([0.5]),
@@ -379,7 +388,7 @@ def calculate_mass_transfer_single_species(
         "particle_concentration": "nonnegative",
     }
 )
-def calculate_mass_transfer_multiple_species(
+def get_mass_transfer_of_multiple_species(
     mass_rate: NDArray[np.float64],
     time_step: float,
     gas_mass: NDArray[np.float64],
@@ -411,7 +420,8 @@ def calculate_mass_transfer_multiple_species(
 
     Examples:
         ```py title="Multiple species input"
-        calculate_mass_transfer_multiple_species(
+        import particula as par
+        par.dynamics.get_mass_transfer_of_multiple_species(
             mass_rate=np.array([[0.1, 0.05, 0.03], [0.2, 0.15, 0.07]]),
             time_step=10,
             gas_mass=np.array([1.0, 0.8, 0.5]),

--- a/particula/dynamics/condensation/tests/condensation_strategies_test.py
+++ b/particula/dynamics/condensation/tests/condensation_strategies_test.py
@@ -52,6 +52,8 @@ class TestCondensationIsothermal(unittest.TestCase):
         """Test the first order mass transport call."""
         radius = 1e-9  # m
         result = self.strategy.first_order_mass_transport(
-            radius=radius, temperature=self.temperature, pressure=self.pressure
+            particle_radius=radius,
+            temperature=self.temperature,
+            pressure=self.pressure,
         )
         self.assertIsNotNone(result)

--- a/particula/dynamics/condensation/tests/mass_transfer_test.py
+++ b/particula/dynamics/condensation/tests/mass_transfer_test.py
@@ -2,12 +2,12 @@
 
 import numpy as np
 from particula.dynamics.condensation.mass_transfer import (
-    first_order_mass_transport_k,
-    mass_transfer_rate,
-    calculate_mass_transfer,
-    calculate_mass_transfer_single_species,
-    calculate_mass_transfer_multiple_species,
-    radius_transfer_rate,  # Import the function to be tested
+    get_first_order_mass_transport_k,
+    get_mass_transfer_rate,
+    get_mass_transfer,
+    get_mass_transfer_of_single_species,
+    get_mass_transfer_of_multiple_species,
+    get_radius_transfer_rate,  # Import the function to be tested
 )
 
 
@@ -17,7 +17,7 @@ def test_first_order_mass_transport_k():
     vapor_transition = 0.6
     diffusion_coefficient = 2e-9
     expected_result = 1.5079644737231005e-14
-    result = first_order_mass_transport_k(
+    result = get_first_order_mass_transport_k(
         radius, vapor_transition, diffusion_coefficient
     )
     np.testing.assert_allclose(result, expected_result, rtol=1e-8)
@@ -31,7 +31,7 @@ def test_multi_radius_first_order_mass_transport_k():
     expected_result = np.array(
         [1.50796447e-14, 3.01592895e-14, 4.52389342e-14]
     )
-    result = first_order_mass_transport_k(
+    result = get_first_order_mass_transport_k(
         radius, vapor_transition, diffusion_coefficient
     )
     np.testing.assert_allclose(result, expected_result, rtol=1e-8)
@@ -44,7 +44,7 @@ def test_mass_transfer_rate():
     temperature = 300.0
     molar_mass = 0.02897
     expected_result = 1.16143004e-21
-    result = mass_transfer_rate(
+    result = get_mass_transfer_rate(
         pressure_delta, first_order_mass_transport, temperature, molar_mass
     )
     assert np.isclose(
@@ -60,7 +60,7 @@ def test_mass_transfer_mulit_particle_rate():
     temperature = 300.0
     molar_mass = 0.02897
     expected_result = np.array([1.16143004e-21, 3.48429013e-21])
-    result = mass_transfer_rate(
+    result = get_mass_transfer_rate(
         pressure_delta, first_order_mass_transport, temperature, molar_mass
     )
     np.testing.assert_allclose(result, expected_result, rtol=1e-8)
@@ -73,7 +73,7 @@ def test_multi_species_mass_transfer_rate():
     temperature = 300.0
     molar_mass = np.array([0.02897, 0.018015])
     expected_result = np.array([1.16143004e-21, 2.16670648e-21])
-    result = mass_transfer_rate(
+    result = get_mass_transfer_rate(
         pressure_delta, first_order_mass_transport, temperature, molar_mass
     )
     np.testing.assert_allclose(result, expected_result, rtol=1e-8)
@@ -104,14 +104,14 @@ def test_single_species_condensation_not_enough_gas_mass():
     expected_mass_transfer = total_mass_to_change * scaling_factor
 
     # Calculate using the direct single species function
-    result_direct = calculate_mass_transfer_single_species(
+    result_direct = get_mass_transfer_of_single_species(
         mass_rate, time_step, gas_mass, particle_mass, particle_concentration
     )
     np.testing.assert_allclose(
         result_direct, expected_mass_transfer, rtol=1e-8
     )
     # second calc
-    result_direct2 = calculate_mass_transfer_single_species(
+    result_direct2 = get_mass_transfer_of_single_species(
         mass_rate, time_step, gas_mass, particle_mass, particle_concentration
     )
     np.testing.assert_allclose(
@@ -119,7 +119,7 @@ def test_single_species_condensation_not_enough_gas_mass():
     )
 
     # Calculate using the general helper function
-    result = calculate_mass_transfer(
+    result = get_mass_transfer(
         mass_rate, time_step, gas_mass, particle_mass, particle_concentration
     )
     np.testing.assert_allclose(result, expected_mass_transfer, rtol=1e-8)
@@ -140,14 +140,14 @@ def test_single_species_evaporation_not_enough_particle_mass():
     # However, the transfer is limited by available particle mass: [-0.8, -1.5]
     expected_mass_transfer = np.array([-0.8, -1.5])
 
-    result_direct = calculate_mass_transfer_single_species(
+    result_direct = get_mass_transfer_of_single_species(
         mass_rate, time_step, gas_mass, particle_mass, particle_concentration
     )
     np.testing.assert_allclose(
         result_direct, expected_mass_transfer, rtol=1e-8
     )
 
-    result = calculate_mass_transfer(
+    result = get_mass_transfer(
         mass_rate, time_step, gas_mass, particle_mass, particle_concentration
     )
     np.testing.assert_allclose(result, expected_mass_transfer, rtol=1e-8)
@@ -191,7 +191,7 @@ def test_multiple_species_condensation():
     expected_mass_transfer = mass_to_change * scaling_factor
 
     # Test the direct multiple species function
-    result_direct = calculate_mass_transfer_multiple_species(
+    result_direct = get_mass_transfer_of_multiple_species(
         mass_rate, time_step, gas_mass, particle_mass, particle_concentration
     )
     # Check that the total mass transfer for each gas species is equal to the
@@ -203,7 +203,7 @@ def test_multiple_species_condensation():
     )
 
     # Test the general helper function
-    result = calculate_mass_transfer(
+    result = get_mass_transfer(
         mass_rate, time_step, gas_mass, particle_mass, particle_concentration
     )
     np.testing.assert_allclose(result, expected_mass_transfer, rtol=1e-8)
@@ -245,7 +245,7 @@ def test_multiple_species_evaporation_not_enough_particle_mass():
     )
 
     # Test the direct multiple species function
-    result_direct = calculate_mass_transfer_multiple_species(
+    result_direct = get_mass_transfer_of_multiple_species(
         mass_rate, time_step, gas_mass, particle_mass, particle_concentration
     )
     # Check the individual mass transfer for each particle and species
@@ -259,7 +259,7 @@ def test_multiple_species_evaporation_not_enough_particle_mass():
     )
 
     # Test the general helper function
-    result = calculate_mass_transfer(
+    result = get_mass_transfer(
         mass_rate, time_step, gas_mass, particle_mass, particle_concentration
     )
     np.testing.assert_allclose(result, expected_mass_transfer, rtol=1e-8)
@@ -275,7 +275,7 @@ def test_zero_mass_transfer():
 
     expected_mass_transfer = np.array([0.0])  # No mass transfer should occur
 
-    result = calculate_mass_transfer(
+    result = get_mass_transfer(
         mass_rate, time_step, gas_mass, particle_mass, particle_concentration
     )
     np.testing.assert_array_almost_equal(result, expected_mass_transfer)
@@ -284,18 +284,18 @@ def test_zero_mass_transfer():
 def test_radius_transfer_rate():
     """Test the radius_transfer_rate function."""
     # Test normal case
-    result = radius_transfer_rate(1e-21, 1e-6, 1000)
+    result = get_radius_transfer_rate(1e-21, 1e-6, 1000)
     np.testing.assert_allclose(result, 7.95774715e-14, atol=1e-8)
 
     # Test edge cases
-    np.testing.assert_allclose(radius_transfer_rate(0, 1e-6, 1000), 0)
+    np.testing.assert_allclose(get_radius_transfer_rate(0, 1e-6, 1000), 0)
 
     # Test with array inputs
     mass_rate = np.array([1e-21, 2e-21])  # kg/s
     radius = np.array([1e-6, 2e-6])  # m
     density = 1000  # kg/m^3
     expected_result = np.array([7.95774715e-14, 1.98943679e-14])  # m/s
-    result = radius_transfer_rate(mass_rate, radius, density)
+    result = get_radius_transfer_rate(mass_rate, radius, density)
     np.testing.assert_allclose(result, expected_result, atol=1e-8)
 
     # Test with zero mass rate
@@ -303,5 +303,5 @@ def test_radius_transfer_rate():
     radius = np.array([1e-6, 2e-6])  # m
     density = 1000  # kg/m^3
     expected_result = np.array([7.95774715e-14, 0])  # m/s
-    result = radius_transfer_rate(mass_rate, radius, density)
+    result = get_radius_transfer_rate(mass_rate, radius, density)
     np.testing.assert_allclose(result, expected_result, atol=1e-8)


### PR DESCRIPTION
Fixes #668

Update function names in mass transfer to conform to get_ prefix, and now consistent with rest of code.

## Summary by Sourcery

Updates function names in the mass transfer module to use the `get_` prefix for consistency with the rest of the codebase.

Enhancements:
- Renames functions in `mass_transfer.py` to use the `get_` prefix.
- Updates calls to the renamed functions in `condensation_strategies.py`.
- Updates tests to use the renamed functions.