### PR TITLE
Exposed Sedimentation Coagulation and made Effective density method

### DIFF
--- a/particula/dynamics/__init__.py
+++ b/particula/dynamics/__init__.py
@@ -127,6 +127,9 @@ from particula.dynamics.coagulation.coagulation_builder.turbulent_dns_coagulatio
 from particula.dynamics.coagulation.coagulation_builder.combine_coagulation_strategy_builder import (
     CombineCoagulationStrategyBuilder,
 )
+from particula.dynamics.coagulation.coagulation_builder.sedimentation_coagulation_builder import (
+    SedimentationCoagulationBuilder,
+)
 
 # particula.dynamics.coagulation.particle_resolved_step
 from particula.dynamics.coagulation.particle_resolved_step.particle_resolved_method import (

--- a/particula/dynamics/coagulation/coagulation_strategy/sedimentation_coagulation_strategy.py
+++ b/particula/dynamics/coagulation/coagulation_strategy/sedimentation_coagulation_strategy.py
@@ -125,7 +125,7 @@ class SedimentationCoagulationStrategy(CoagulationStrategyABC):
         """
         return get_sedimentation_kernel_sp2016_via_system_state(
             particle_radius=particle.get_radius(),
-            particle_density=particle.get_density(),
+            particle_density=particle.get_mean_effective_density(),
             temperature=temperature,
             pressure=pressure,
             calculate_collision_efficiency=False,

--- a/particula/dynamics/coagulation/coagulation_strategy/turbulent_dns_coagulation_strategy.py
+++ b/particula/dynamics/coagulation/coagulation_strategy/turbulent_dns_coagulation_strategy.py
@@ -235,18 +235,9 @@ class TurbulentDNSCoagulationStrategy(CoagulationStrategyABC):
           [DOI](https://doi.org/10.1088/1367-2630/10/7/075016)
         """
 
-        # calculate weighted particle density
-        densities = particle.get_density()
-        mass_matrix = np.sum(particle.get_species_mass(), axis=0)
-        # mass weighted average
-        particle_density = (
-            np.sum(mass_matrix * densities)
-            / np.sum(mass_matrix, axis=0)
-        )
-
         return get_turbulent_dns_kernel_ao2008_via_system_state(
             particle_radius=particle.get_radius(),
-            particle_density=particle_density,
+            particle_density=particle.get_mean_effective_density(),
             fluid_density=self.fluid_density,
             turbulent_dissipation=self.turbulent_dissipation,
             re_lambda=self.reynolds_lambda,

--- a/particula/particles/representation.py
+++ b/particula/particles/representation.py
@@ -284,8 +284,7 @@ class ParticleRepresentation:
             out=np.zeros_like(weighted_mass),
         )
 
-    def get_mean_effective_density(self) -> NDArray[np.float64]:
-        """
+    def get_mean_effective_density(self) -> float:
         Return the mean effective density of the particles.
 
         Arguments:

--- a/particula/particles/representation.py
+++ b/particula/particles/representation.py
@@ -254,6 +254,60 @@ class ParticleRepresentation:
             return np.copy(self.density)
         return self.density
 
+    def get_effective_density(self) -> NDArray[np.float64]:
+        """
+        Return the effective density of the particles, weighted by the
+        mass of the species.
+
+        Arguments:
+            - None
+
+        Returns:
+            - The effective density of the particles.
+
+        Example:
+            ``` py title="Get Effective Density Array"
+            effective_density = particle_representation.get_effective_density()
+            ```
+        """
+        densities = self.get_density()
+        # if only one species is used, return the density of that species
+        if isinstance(densities, float) or np.size(densities) == 1:
+            return np.ones_like(self.get_species_mass()) * densities
+        # calculate weighted particle density
+        mass_total = self.get_mass()
+        weighted_mass = np.sum(self.get_species_mass() * densities, axis=1)
+        return np.divide(
+            weighted_mass,
+            mass_total,
+            where=mass_total != 0,
+            out=np.zeros_like(weighted_mass),
+        )
+
+    def get_mean_effective_density(self) -> NDArray[np.float64]:
+        """
+        Return the mean effective density of the particles.
+
+        Arguments:
+            - None
+
+        Returns:
+            - The mean effective density of the particles.
+
+        Example:
+            ``` py title="Get Mean Effective Density Array"
+            mean_effective_density = (
+                particle_representation.get_mean_effective_density()
+            )
+            ```
+        """
+        # filter out zero densities for no mass in bin/particle
+        effective_density = self.get_effective_density()
+        effective_density = effective_density[effective_density != 0]
+        if effective_density.size == 0:
+            return 0.0
+        return np.mean(self.get_effective_density())
+
     def get_concentration(self, clone: bool = False) -> NDArray[np.float64]:
         """
         Return the volume concentration of the particles.

--- a/particula/particles/representation.py
+++ b/particula/particles/representation.py
@@ -285,6 +285,7 @@ class ParticleRepresentation:
         )
 
     def get_mean_effective_density(self) -> float:
+        """
         Return the mean effective density of the particles.
 
         Arguments:

--- a/particula/particles/representation.py
+++ b/particula/particles/representation.py
@@ -18,7 +18,7 @@ from particula.particles.distribution_strategies import (
 logger = logging.getLogger("particula")
 
 
-# pylint: disable=too-many-instance-attributes
+# pylint: disable=too-many-instance-attributes, too-many-public-methods
 class ParticleRepresentation:
     """Everything needed to represent a particle or a collection of particles.
 

--- a/particula/particles/representation.py
+++ b/particula/particles/representation.py
@@ -306,7 +306,7 @@ class ParticleRepresentation:
         effective_density = effective_density[effective_density != 0]
         if effective_density.size == 0:
             return 0.0
-        return np.mean(self.get_effective_density())
+        return np.mean(effective_density)
 
     def get_concentration(self, clone: bool = False) -> NDArray[np.float64]:
         """

--- a/particula/particles/tests/representation_test.py
+++ b/particula/particles/tests/representation_test.py
@@ -214,9 +214,7 @@ def test_get_mean_effective_density():
     effective_density = particle.get_effective_density()
     # Filter out any zero entries before computing mean
     effective_density_nonzero = effective_density[effective_density != 0]
-    expected_mean = 0.0
-    if effective_density_nonzero.size > 0:
-        expected_mean = np.mean(effective_density_nonzero)
+    expected_mean = np.mean(effective_density_nonzero)
 
     assert isinstance(med, float)
     assert np.isclose(med, expected_mean, rtol=1e-7)


### PR DESCRIPTION
In running the paper example.

- The sedimentation coagulation builder was not exposed in the init, so I changed that.
- Then this sed. kernel also needs the effective density (like the DNS kernerl) so I moved that calc to the particle representation object as a method. Then updated both calls.

## Summary by Sourcery

Add effective density calculation methods to particle representation and expose sedimentation coagulation strategy

New Features:
- Introduced methods to calculate effective density for particles, including get_effective_density() and get_mean_effective_density()

Enhancements:
- Updated coagulation strategies to use mean effective density instead of direct density
- Added support for multi-species particle density calculations

Tests:
- Added comprehensive test cases for effective density methods
- Created test scenarios for single-species and multi-species particle representations