### PR TITLE
get rid of pytest.ini file for simpler -W filter

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest
+        pytest -Werror

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-filterwarnings = error


### PR DESCRIPTION
A minor thing I noticed. Instead of adding a file, we can do with the -W filter (does the same thing anyway)

## Summary by Sourcery

Remove pytest.ini configuration and use command-line warning filter instead

CI:
- Update test workflow to use pytest -Werror flag directly instead of relying on pytest.ini configuration

Chores:
- Remove pytest.ini configuration file to simplify project setup