### PR TITLE
ADDED Csat Builder and Clearer VaporPressureBuilder Names

### DIFF
--- a/particula/gas/__init__.py
+++ b/particula/gas/__init__.py
@@ -14,10 +14,11 @@ from particula.gas.vapor_pressure_strategies import (
 )
 
 from particula.gas.vapor_pressure_builders import (
-    ConstantBuilder,
-    AntoineBuilder,
-    ClausiusClapeyronBuilder,
-    WaterBuckBuilder,
+    ConstantVaporPressureBuilder,
+    AntoineVaporPressureBuilder,
+    ClausiusClapeyronVaporPressureBuilder,
+    WaterBuckVaporPressureBuilder,
+    SaturationConcentrationVaporPressureBuilder,
 )
 from particula.gas.vapor_pressure_factories import VaporPressureFactory
 from particula.gas.species import GasSpecies

--- a/particula/gas/properties/concentration_function.py
+++ b/particula/gas/properties/concentration_function.py
@@ -1,4 +1,4 @@
-"""Function for calculating the gas concentraions."""
+"""Function for calculating the gas concentrations."""
 
 from typing import Union
 from numpy.typing import NDArray

--- a/particula/gas/tests/vapor_pressure_builders_test.py
+++ b/particula/gas/tests/vapor_pressure_builders_test.py
@@ -2,23 +2,23 @@
 
 import pytest
 from particula.gas.vapor_pressure_builders import (
-    AntoineBuilder,
-    ClausiusClapeyronBuilder,
-    ConstantBuilder,
-    WaterBuckBuilder,
+    AntoineVaporPressureBuilder,
+    ClausiusClapeyronVaporPressureBuilder,
+    ConstantVaporPressureBuilder,
+    WaterBuckVaporPressureBuilder,
     SaturationConcentrationVaporPressureBuilder,
 )
 
 
 def test_antoine_set_positive_a():
     """Test setting a positive value for the coefficient 'a'."""
-    builder = AntoineBuilder()
+    builder = AntoineVaporPressureBuilder()
     assert builder.set_a(10).a == 10
 
 
 def test_antoine_set_negative_a():
     """Test setting a negative value for the coefficient 'a'."""
-    builder = AntoineBuilder()
+    builder = AntoineVaporPressureBuilder()
     with pytest.raises(ValueError) as excinfo:
         builder.set_a(-5)
     assert "Coefficient 'a' must be a positive value." in str(excinfo.value)
@@ -26,7 +26,7 @@ def test_antoine_set_negative_a():
 
 def test_antoine_set_parameters_with_missing_key():
     """Test setting parameters with a missing key in the dictionary."""
-    builder = AntoineBuilder()
+    builder = AntoineVaporPressureBuilder()
     with pytest.raises(ValueError) as excinfo:
         builder.set_parameters({"a": 10, "b": 2000})
     assert "Missing required parameter(s): c" in str(excinfo.value)
@@ -34,7 +34,7 @@ def test_antoine_set_parameters_with_missing_key():
 
 def test_antoine_build_without_all_coefficients():
     """Test building the strategy without all coefficients set."""
-    builder = AntoineBuilder().set_a(10).set_b(2000)
+    builder = AntoineVaporPressureBuilder().set_a(10).set_b(2000)
     with pytest.raises(ValueError) as excinfo:
         builder.build()
     assert "Required parameter(s) not set: c" in str(excinfo.value)
@@ -42,49 +42,49 @@ def test_antoine_build_without_all_coefficients():
 
 def test_clausius_set_latent_heat_positive():
     """Test setting a positive value for the latent heat."""
-    builder = ClausiusClapeyronBuilder()
+    builder = ClausiusClapeyronVaporPressureBuilder()
     builder.set_latent_heat(100, "J/mol")
     assert builder.latent_heat == 100, "Latent heat should be set correctly"
 
 
 def test_clausius_set_latent_heat_negative():
     """Test setting a negative value for the latent heat."""
-    builder = ClausiusClapeyronBuilder()
+    builder = ClausiusClapeyronVaporPressureBuilder()
     with pytest.raises(ValueError):
         builder.set_latent_heat(-100, "J/mol")
 
 
 def test_clausius_set_temperature_initial_positive():
     """Test setting a positive value for the initial temperature."""
-    builder = ClausiusClapeyronBuilder()
+    builder = ClausiusClapeyronVaporPressureBuilder()
     builder.set_temperature_initial(300, "K")
     assert builder.temperature_initial == 300
 
 
 def test_clausius_set_temperature_initial_negative():
     """Test setting a negative value for the initial temperature."""
-    builder = ClausiusClapeyronBuilder()
+    builder = ClausiusClapeyronVaporPressureBuilder()
     with pytest.raises(ValueError):
         builder.set_temperature_initial(-5, "K")
 
 
 def test_clausius_set_pressure_initial_positive():
     """Test setting a positive value for the initial pressure."""
-    builder = ClausiusClapeyronBuilder()
+    builder = ClausiusClapeyronVaporPressureBuilder()
     builder.set_pressure_initial(101325, "Pa")
     assert builder.pressure_initial == 101325
 
 
 def test_clausius_set_pressure_initial_negative():
     """Test setting a negative value for the initial pressure."""
-    builder = ClausiusClapeyronBuilder()
+    builder = ClausiusClapeyronVaporPressureBuilder()
     with pytest.raises(ValueError):
         builder.set_pressure_initial(-101325, "Pa")
 
 
 def test_clausius_set_parameters_complete():
     """Test setting all parameters at once, with different pressure units."""
-    builder = ClausiusClapeyronBuilder()
+    builder = ClausiusClapeyronVaporPressureBuilder()
     parameters = {
         "latent_heat": 2260,
         "latent_heat_units": "J/mol",
@@ -102,7 +102,7 @@ def test_clausius_set_parameters_complete():
 def test_clausius_build_success():
     """Test building the strategy successfully."""
     builder = (
-        ClausiusClapeyronBuilder()
+        ClausiusClapeyronVaporPressureBuilder()
         .set_latent_heat(2260, "J/mol")
         .set_temperature_initial(373, "K")
         .set_pressure_initial(101325, "Pa")
@@ -112,7 +112,7 @@ def test_clausius_build_success():
 
 def test_clausius_build_failure():
     """Test building the strategy without all parameters set."""
-    builder = ClausiusClapeyronBuilder()
+    builder = ClausiusClapeyronVaporPressureBuilder()
     builder.set_latent_heat(2260, "J/mol").set_temperature_initial(373, "K")
     with pytest.raises(ValueError) as excinfo:
         builder.build()
@@ -123,21 +123,21 @@ def test_clausius_build_failure():
 
 def test_constant_set_vapor_pressure_positive():
     """Test setting a positive value for the constant vapor pressure."""
-    builder = ConstantBuilder()
+    builder = ConstantVaporPressureBuilder()
     builder.set_vapor_pressure(101325, "Pa")
     assert builder.vapor_pressure == 101325
 
 
 def test_constant_set_vapor_pressure_negative():
     """Test setting a negative value for the constant vapor pressure."""
-    builder = ConstantBuilder()
+    builder = ConstantVaporPressureBuilder()
     with pytest.raises(ValueError):
         builder.set_vapor_pressure(-101325, "Pa")
 
 
 def test_constant_set_parameters_complete():
     """Test setting all parameters at once. With different pressure units."""
-    builder = ConstantBuilder()
+    builder = ConstantVaporPressureBuilder()
     parameters = {"vapor_pressure": 101325, "vapor_pressure_units": "Pa"}
     builder.set_parameters(parameters)
     assert builder.vapor_pressure == 101325
@@ -145,14 +145,14 @@ def test_constant_set_parameters_complete():
 
 def test_constant_build_success():
     """Test building the strategy successfully."""
-    builder = ConstantBuilder()
+    builder = ConstantVaporPressureBuilder()
     builder.set_vapor_pressure(101325, "Pa")
     builder.build()
 
 
 def test_constant_build_failure():
     """Test building the strategy without setting the vapor pressure."""
-    builder = ConstantBuilder()
+    builder = ConstantVaporPressureBuilder()
     with pytest.raises(ValueError) as excinfo:
         builder.build()
     assert "Required parameter(s) not set: vapor_pressure" in str(
@@ -162,7 +162,7 @@ def test_constant_build_failure():
 
 def test_build_water_buck():
     """Test building the WaterBuck strategy."""
-    builder = WaterBuckBuilder()
+    builder = WaterBuckVaporPressureBuilder()
     builder.build()
 
 

--- a/particula/gas/tests/vapor_pressure_builders_test.py
+++ b/particula/gas/tests/vapor_pressure_builders_test.py
@@ -6,6 +6,7 @@ from particula.gas.vapor_pressure_builders import (
     ClausiusClapeyronBuilder,
     ConstantBuilder,
     WaterBuckBuilder,
+    SaturationConcentrationVaporPressureBuilder,
 )
 
 
@@ -163,3 +164,38 @@ def test_build_water_buck():
     """Test building the WaterBuck strategy."""
     builder = WaterBuckBuilder()
     builder.build()
+
+
+# ----------------------------------------------------------------------
+# SaturationConcentrationVaporPressureBuilder tests
+# ----------------------------------------------------------------------
+
+
+def test_saturation_set_concentration_positive():
+    """Test setting a positive saturation concentration (default units)."""
+    builder = SaturationConcentrationVaporPressureBuilder()
+    builder.set_saturation_concentration(1e-6, "kg/m^3")
+    assert builder.saturation_concentration == pytest.approx(1e-6)
+
+
+def test_saturation_build_success():
+    """Test successful build when all parameters are provided."""
+    builder = (
+        SaturationConcentrationVaporPressureBuilder()
+        .set_saturation_concentration(1e-6, "kg/m^3")
+        .set_molar_mass(0.018, "kg/mol")
+        .set_temperature(298.15, "K")
+    )
+    builder.build()  # Should not raise
+
+
+def test_saturation_build_failure_missing_param():
+    """Test build failure when temperature is missing."""
+    builder = (
+        SaturationConcentrationVaporPressureBuilder()
+        .set_saturation_concentration(1e-6, "kg/m^3")
+        .set_molar_mass(0.018, "kg/mol")
+    )
+    with pytest.raises(ValueError) as excinfo:
+        builder.build()
+    assert "Required parameter(s) not set: temperature" in str(excinfo.value)

--- a/particula/gas/tests/vapor_pressure_factories_test.py
+++ b/particula/gas/tests/vapor_pressure_factories_test.py
@@ -44,7 +44,6 @@ def test_factory_with_clausius_clapeyron_strategy():
     assert isinstance(strategy, ClausiusClapeyronStrategy)
 
 
-
 def test_factory_with_water_buck_strategy():
     """Test factory creates a WaterBuckStrategy correctly without
     parameters."""

--- a/particula/gas/tests/vapor_pressure_factories_test.py
+++ b/particula/gas/tests/vapor_pressure_factories_test.py
@@ -44,11 +44,30 @@ def test_factory_with_clausius_clapeyron_strategy():
     assert isinstance(strategy, ClausiusClapeyronStrategy)
 
 
+
 def test_factory_with_water_buck_strategy():
     """Test factory creates a WaterBuckStrategy correctly without
     parameters."""
     strategy = VaporPressureFactory().get_strategy(strategy_type="water_buck")
     assert isinstance(strategy, WaterBuckStrategy)
+
+
+def test_factory_with_saturation_concentration_strategy():
+    """Test factory creates a ConstantVaporPressureStrategy from the
+    SaturationConcentrationVaporPressureBuilder."""
+    parameters = {
+        "saturation_concentration": 1e-6,
+        "saturation_concentration_units": "kg/m^3",
+        "molar_mass": 0.018,
+        "molar_mass_units": "kg/mol",
+        "temperature": 298.15,
+        "temperature_units": "K",
+    }
+    strategy = VaporPressureFactory().get_strategy(
+        strategy_type="saturation_concentration",
+        parameters=parameters,
+    )
+    assert isinstance(strategy, ConstantVaporPressureStrategy)
 
 
 def test_factory_with_unknown_strategy():

--- a/particula/gas/vapor_pressure_builders.py
+++ b/particula/gas/vapor_pressure_builders.py
@@ -22,12 +22,16 @@ import logging
 from typing import Optional
 
 from particula.abc_builder import BuilderABC
+from particula.builder_mixin import (
+    BuilderMolarMassMixin, BuilderTemperatureMixin
+)
 from particula.gas.vapor_pressure_strategies import (
     AntoineVaporPressureStrategy,
     ClausiusClapeyronStrategy,
     WaterBuckStrategy,
     ConstantVaporPressureStrategy,
 )
+from particula.gas.properties.pressure_function import get_partial_pressure
 from particula.util.validate_inputs import validate_inputs
 from particula.util import get_unit_conversion
 
@@ -303,6 +307,65 @@ class ConstantBuilder(BuilderABC):
         """
         self.pre_build_check()
         return ConstantVaporPressureStrategy(self.vapor_pressure)
+
+
+class SaturationConcentrationVaporPressureBuilder(
+    BuilderABC,
+    BuilderMolarMassMixin,
+    BuilderTemperatureMixin,
+    ):
+    """Builder class for SaturationConcentrationVaporPressureStrategy.
+
+    This class facilitates the building of the
+    SaturationConcentrationVaporPressureStrategy object. It allows
+    for setting the vapor pressure using the saturation concentration,
+    molar mass, and temperature. The saturation concentration is commonly
+    called C^sat or C* when in a mixture.
+
+    Example:
+        ```py title="SaturationConcentrationVaporPressureBuilder"
+        import particula as par
+        strategy = par.gas.SaturationConcentrationVaporPressureBuilder().build()
+        ```
+    """
+
+    def __init__(self):
+        required_parameters = [
+            "saturation_concentration",
+            "molar_mass",
+            "temperature"
+        ]
+        BuilderABC.__init__(self, required_parameters)
+        BuilderMolarMassMixin.__init__(self)
+        BuilderTemperatureMixin.__init__(self)
+        self.saturation_concentration = None
+        self.molar_mass = None
+        self.temperature = None
+
+    def set_saturation_concentration(
+        self, saturation_concentration: float, units: str = "kg/m^3"
+    )
+        """Set the saturation concentration in kg/m^3.
+        
+        
+        
+        """
+        
+
+
+    def build(self) -> ConstantVaporPressureStrategy:
+        """
+
+        """
+        self.pre_build_check()
+
+        return ConstantVaporPressureStrategy(
+            vapor_pressure=get_partial_pressure(
+                self.saturation_concentration,
+                self.molar_mass,
+                self.temperature,
+            )
+        )
 
 
 class WaterBuckBuilder(BuilderABC):  # pylint: disable=too-few-public-methods

--- a/particula/gas/vapor_pressure_builders.py
+++ b/particula/gas/vapor_pressure_builders.py
@@ -264,17 +264,17 @@ class ConstantVaporPressureBuilder(BuilderABC):
     - build : Validate parameters and return a ConstantVaporPressureStrategy.
 
     Example:
-        ``` py title="ConstatnVaporPressureBuilder"
+        ``` py title="ConstantVaporPressureBuilder"
         strategy = (
-            ConstatnVaporPressureBuilder()
+            ConstantVaporPressureBuilder()
             .set_vapor_pressure(101325)
             .build()
         )
         ```
 
-        ``` py title="ConstatnVaporPressureBuilder with units"
+        ``` py title="ConstantVaporPressureBuilder with units"
         strategy = (
-            ConstatnVaporPressureBuilder()
+            ConstantVaporPressureBuilder()
             .set_vapor_pressure(1, "atm")
             .build()
         )

--- a/particula/gas/vapor_pressure_builders.py
+++ b/particula/gas/vapor_pressure_builders.py
@@ -319,12 +319,18 @@ class SaturationConcentrationVaporPressureBuilder(
     BuilderMolarMassMixin,
     BuilderTemperatureMixin,
 ):
-    """Builder class for SaturationConcentrationVaporPressureStrategy.
+    """Builder class for ConstantVaporPressureStrategy.
 
-    This class facilitates the building of the ConstantVaporPressureStrategy.
     It allows for setting the vapor pressure using the saturation
     concentration, molar mass, and temperature. The saturation concentration is
     commonly called C^sat (or C* when in a mixture) in aerosol sciences.
+
+    Methods:
+    - set_saturation_concentration : Set the saturation concentration in
+      kg/m³ (or convertible units).
+    - set_molar_mass : Set the molar mass in kg/mol (or convertible units).
+    - set_temperature : Set the temperature in K (or convertible units).
+    - build : Validate parameters and return a ConstantVaporPressureStrategy.
 
     Example:
         ```py title="SaturationConcentrationVaporPressureBuilder"
@@ -367,13 +373,13 @@ class SaturationConcentrationVaporPressureBuilder(
         """
         Set the saturation concentration (C*, C^sat).
 
-        Parameters:
+        Arguments:
             - saturation_concentration : Value of the saturation concentration.
             - saturation_concentration_units : Any units convertible to
                 ``"kg/m^3"`` via ``get_unit_conversion`` are accepted.
 
         Returns:
-           - self, The builder itself for fluent chaining.
+           - The builder itself for fluent chaining.
 
         Example:
             ```py title="SaturationConcentrationVaporPressureBuilder"
@@ -400,7 +406,8 @@ class SaturationConcentrationVaporPressureBuilder(
         ideal-gas relationship between concentration and partial pressure.
 
         Returns:
-            Strategy containing the calculated vapor pressure.
+            ConstantVaporPressureStrategy containing the calculated vapor
+            pressure.
         """
         self.pre_build_check()
 
@@ -409,7 +416,6 @@ class SaturationConcentrationVaporPressureBuilder(
             molar_mass=self.molar_mass,
             temperature=self.temperature,
         )
-
         return ConstantVaporPressureStrategy(vapor_pressure)
 
 

--- a/particula/gas/vapor_pressure_builders.py
+++ b/particula/gas/vapor_pressure_builders.py
@@ -23,7 +23,8 @@ from typing import Optional
 
 from particula.abc_builder import BuilderABC
 from particula.builder_mixin import (
-    BuilderMolarMassMixin, BuilderTemperatureMixin
+    BuilderMolarMassMixin,
+    BuilderTemperatureMixin,
 )
 from particula.gas.vapor_pressure_strategies import (
     AntoineVaporPressureStrategy,
@@ -38,7 +39,7 @@ from particula.util import get_unit_conversion
 logger = logging.getLogger("particula")
 
 
-class AntoineBuilder(BuilderABC):
+class AntoineVaporPressureBuilder(BuilderABC):
     """
     Builder class for AntoineVaporPressureStrategy. It allows setting
     the coefficients 'a', 'b', and 'c' separately and then building the
@@ -59,9 +60,9 @@ class AntoineBuilder(BuilderABC):
     - build : Validate parameters and return an AntoineVaporPressureStrategy.
 
     Example:
-        ``` py title="AntoineBuilder"
+        ``` py title="AntoineVaporPressureBuilder"
         strategy = (
-            AntoineBuilder()
+            AntoineVaporPressureBuilder()
             .set_a(8.07131)
             .set_b(1730.63)
             .set_c(233.426)
@@ -69,9 +70,9 @@ class AntoineBuilder(BuilderABC):
         )
         ```
 
-        ``` py title="AntoineBuilder with units"
+        ``` py title="AntoineVaporPressureBuilder with units"
         strategy = (
-            AntoineBuilder()
+            AntoineVaporPressureBuilder()
             .set_a(8.07131)
             .set_b(1730.63, "K")
             .set_c(233.426, "K")
@@ -98,7 +99,7 @@ class AntoineBuilder(BuilderABC):
 
     def set_a(
         self, a: float, a_units: Optional[str] = None
-    ) -> "AntoineBuilder":
+    ) -> "AntoineVaporPressureBuilder":
         """Set the coefficient 'a' of the Antoine equation."""
         if a < 0:
             logger.error("Coefficient 'a' must be a positive value.")
@@ -109,7 +110,9 @@ class AntoineBuilder(BuilderABC):
         return self
 
     @validate_inputs({"b": "positive"})
-    def set_b(self, b: float, b_units: str = "K") -> "AntoineBuilder":
+    def set_b(
+        self, b: float, b_units: str = "K"
+    ) -> "AntoineVaporPressureBuilder":
         """Set the coefficient 'b' of the Antoine equation."""
         if b_units == "K":
             self.b = b
@@ -117,7 +120,9 @@ class AntoineBuilder(BuilderABC):
         raise ValueError("Only K units are supported for coefficient 'b'.")
 
     @validate_inputs({"c": "positive"})
-    def set_c(self, c: float, c_units: str = "K") -> "AntoineBuilder":
+    def set_c(
+        self, c: float, c_units: str = "K"
+    ) -> "AntoineVaporPressureBuilder":
         """Set the coefficient 'c' of the Antoine equation."""
         if c_units == "K":
             self.c = c
@@ -136,7 +141,7 @@ class AntoineBuilder(BuilderABC):
         return AntoineVaporPressureStrategy(self.a, self.b, self.c)
 
 
-class ClausiusClapeyronBuilder(BuilderABC):
+class ClausiusClapeyronVaporPressureBuilder(BuilderABC):
     """Builder class for ClausiusClapeyronStrategy. This class facilitates
     setting the latent heat of vaporization, initial temperature, and initial
     pressure with unit handling and then builds the strategy object.
@@ -156,9 +161,9 @@ class ClausiusClapeyronBuilder(BuilderABC):
 
 
     Example:
-        ``` py title="ClausiusClapeyronBuilder"
+        ``` py title="ClausiusClapeyronVaporPressureBuilder"
         strategy = (
-            ClausiusClapeyronBuilder()
+            ClausiusClapeyronVaporPressureBuilder()
             .set_latent_heat(2260)
             .set_temperature_initial(373.15)
             .set_pressure_initial(101325)
@@ -166,9 +171,9 @@ class ClausiusClapeyronBuilder(BuilderABC):
         )
         ```
 
-        ``` py title="ClausiusClapeyronBuilder with units"
+        ``` py title="ClausiusClapeyronVaporPressureBuilder with units"
         strategy = (
-            ClausiusClapeyronBuilder()
+            ClausiusClapeyronVaporPressureBuilder()
             .set_latent_heat(2260, "J/mol")
             .set_temperature_initial(373.15, "K")
             .set_pressure_initial(101325, "Pa")
@@ -195,7 +200,7 @@ class ClausiusClapeyronBuilder(BuilderABC):
     @validate_inputs({"latent_heat": "positive"})
     def set_latent_heat(
         self, latent_heat: float, latent_heat_units: str
-    ) -> "ClausiusClapeyronBuilder":
+    ) -> "ClausiusClapeyronVaporPressureBuilder":
         """Set the latent heat of vaporization: Default units J/mol."""
         if latent_heat_units == "J/mol":
             self.latent_heat = latent_heat
@@ -208,7 +213,7 @@ class ClausiusClapeyronBuilder(BuilderABC):
     @validate_inputs({"temperature_initial": "positive"})
     def set_temperature_initial(
         self, temperature_initial: float, temperature_initial_units: str
-    ) -> "ClausiusClapeyronBuilder":
+    ) -> "ClausiusClapeyronVaporPressureBuilder":
         """Set the initial temperature. Default units: K."""
         if temperature_initial_units == "K":
             self.temperature_initial = temperature_initial
@@ -221,7 +226,7 @@ class ClausiusClapeyronBuilder(BuilderABC):
     @validate_inputs({"pressure_initial": "positive"})
     def set_pressure_initial(
         self, pressure_initial: float, pressure_initial_units: str
-    ) -> "ClausiusClapeyronBuilder":
+    ) -> "ClausiusClapeyronVaporPressureBuilder":
         """Set the initial pressure. Default units: Pa."""
         if pressure_initial_units == "Pa":
             self.pressure_initial = pressure_initial
@@ -246,7 +251,7 @@ class ClausiusClapeyronBuilder(BuilderABC):
         )
 
 
-class ConstantBuilder(BuilderABC):
+class ConstantVaporPressureBuilder(BuilderABC):
     """Builder class for ConstantVaporPressureStrategy. This class facilitates
     setting the constant vapor pressure and then building the strategy object.
 
@@ -259,17 +264,17 @@ class ConstantBuilder(BuilderABC):
     - build : Validate parameters and return a ConstantVaporPressureStrategy.
 
     Example:
-        ``` py title="ConstantBuilder"
+        ``` py title="ConstatnVaporPressureBuilder"
         strategy = (
-            ConstantBuilder()
+            ConstatnVaporPressureBuilder()
             .set_vapor_pressure(101325)
             .build()
         )
         ```
 
-        ``` py title="ConstantBuilder with units"
+        ``` py title="ConstatnVaporPressureBuilder with units"
         strategy = (
-            ConstantBuilder()
+            ConstatnVaporPressureBuilder()
             .set_vapor_pressure(1, "atm")
             .build()
         )
@@ -288,7 +293,7 @@ class ConstantBuilder(BuilderABC):
     @validate_inputs({"vapor_pressure": "positive"})
     def set_vapor_pressure(
         self, vapor_pressure: float, vapor_pressure_units: str
-    ) -> "ConstantBuilder":
+    ) -> "ConstantVaporPressureBuilder":
         """Set the constant vapor pressure."""
         if vapor_pressure_units == "Pa":
             self.vapor_pressure = vapor_pressure
@@ -313,27 +318,36 @@ class SaturationConcentrationVaporPressureBuilder(
     BuilderABC,
     BuilderMolarMassMixin,
     BuilderTemperatureMixin,
-    ):
+):
     """Builder class for SaturationConcentrationVaporPressureStrategy.
 
-    This class facilitates the building of the
-    SaturationConcentrationVaporPressureStrategy object. It allows
-    for setting the vapor pressure using the saturation concentration,
-    molar mass, and temperature. The saturation concentration is commonly
-    called C^sat or C* when in a mixture.
+    This class facilitates the building of the ConstantVaporPressureStrategy.
+    It allows for setting the vapor pressure using the saturation
+    concentration, molar mass, and temperature. The saturation concentration is
+    commonly called C^sat (or C* when in a mixture) in aerosol sciences.
 
     Example:
         ```py title="SaturationConcentrationVaporPressureBuilder"
         import particula as par
-        strategy = par.gas.SaturationConcentrationVaporPressureBuilder().build()
+        strategy = (
+            par.gas.SaturationConcentrationVaporPressureBuilder()
+            .set_saturation_concentration(10e-6, "kg/m^3")
+            .set_molar_mass(0.200, "kg/mol")
+            .set_temperature(298.15, "K")
+            .build()
+        )
         ```
+
+    References:
+    - Neil Donahue, "Aerosol Science: Principles, Practice, and Measurement,"
+
     """
 
     def __init__(self):
         required_parameters = [
             "saturation_concentration",
             "molar_mass",
-            "temperature"
+            "temperature",
         ]
         BuilderABC.__init__(self, required_parameters)
         BuilderMolarMassMixin.__init__(self)
@@ -346,59 +360,44 @@ class SaturationConcentrationVaporPressureBuilder(
     def set_saturation_concentration(
         self,
         saturation_concentration: float,
-        units: str = "kg/m^3",
+        saturation_concentration_units: str,
     ) -> "SaturationConcentrationVaporPressureBuilder":
         """
         Set the saturation concentration (C*, C^sat).
 
-        Parameters
-        ----------
-        saturation_concentration : float
-            Value of the saturation concentration.
-        units : str, default ``"kg/m^3"``
-            Units of the supplied value. Any units convertible to
-            ``"kg/m^3"`` via ``get_unit_conversion`` are accepted.
+        Parameters:
+            - saturation_concentration : Value of the saturation concentration.
+            - saturation_concentration_units : Any units convertible to
+                ``"kg/m^3"`` via ``get_unit_conversion`` are accepted.
 
-        Returns
-        -------
-        SaturationConcentrationVaporPressureBuilder
-            The builder itself for fluent chaining.
+        Returns:
+           - self, The builder itself for fluent chaining.
 
-        Raises
-        ------
-        ValueError
-            If the units cannot be converted to ``kg/m^3``.
+        Example:
+            ```py title="SaturationConcentrationVaporPressureBuilder"
+            import particula as par
+            strategy = (
+                par.gas.SaturationConcentrationVaporPressureBuilder()
+                .set_saturation_concentration(10e-6, "kg/m^3")
+            )
+            ```
         """
-        if units == "kg/m^3":
+        if saturation_concentration_units == "kg/m^3":
             self.saturation_concentration = saturation_concentration
             return self
-        try:
-            factor = get_unit_conversion(units, "kg/m^3")
-        except Exception as exc:
-            logger.error("Cannot convert %s to kg/m^3", units)
-            raise ValueError(
-                f"Units '{units}' not convertible to kg/m^3."
-            ) from exc
-        self.saturation_concentration = saturation_concentration * factor
+        self.saturation_concentration = (
+            saturation_concentration
+            * get_unit_conversion(saturation_concentration_units, "kg/m^3")
+        )
         return self
-
 
     def build(self) -> ConstantVaporPressureStrategy:
         """
         Validate all parameters and construct a
         ConstantVaporPressureStrategy whose value is obtained from the
-        ideal–gas relation
+        ideal-gas relationship between concentration and partial pressure.
 
-            P = C * R * T / M
-
-        where
-          C : saturation mass concentration (kg m⁻³)
-          M : molar mass (kg mol⁻¹)
-          T : temperature (K)
-
-        Returns
-        -------
-        ConstantVaporPressureStrategy
+        Returns:
             Strategy containing the calculated vapor pressure.
         """
         self.pre_build_check()
@@ -412,7 +411,9 @@ class SaturationConcentrationVaporPressureBuilder(
         return ConstantVaporPressureStrategy(vapor_pressure)
 
 
-class WaterBuckBuilder(BuilderABC):  # pylint: disable=too-few-public-methods
+class WaterBuckVaporPressureBuilder(
+    BuilderABC
+):  # pylint: disable=too-few-public-methods
     """Builder class for WaterBuckStrategy.
 
     This class facilitates the building of the WaterBuckStrategy object.
@@ -420,9 +421,9 @@ class WaterBuckBuilder(BuilderABC):  # pylint: disable=too-few-public-methods
     extended in the future (e.g., ice-only calculations).
 
     Example:
-        ```py title="WaterBuckBuilder"
+        ```py title="WaterBuckVaporPressureBuilder"
         import particula as par
-        strategy = par.gas.WaterBuckBuilder().build()
+        strategy = par.gas.WaterBuckVaporPressureBuilder().build()
         ```
     """
 

--- a/particula/gas/vapor_pressure_builders.py
+++ b/particula/gas/vapor_pressure_builders.py
@@ -339,8 +339,10 @@ class SaturationConcentrationVaporPressureBuilder(
         ```
 
     References:
-    - Neil Donahue, "Aerosol Science: Principles, Practice, and Measurement,"
-
+    - Donahue, N. M., Robinson, A. L., Stanier, C. O., & Pandis, S. N. (2006).
+      Coupled Partitioning, Dilution, and Chemical Aging of Semivolatile
+      Organics. Environmental Science & Technology, 40(8), 2635–2643.
+      [DOI](https://doi.org/10.1021/es052297c)
     """
 
     def __init__(self):

--- a/particula/gas/vapor_pressure_factories.py
+++ b/particula/gas/vapor_pressure_factories.py
@@ -6,10 +6,11 @@ builders.
 from typing import Union
 from particula.abc_factory import StrategyFactoryABC
 from particula.gas.vapor_pressure_builders import (
-    ConstantBuilder,
-    AntoineBuilder,
-    ClausiusClapeyronBuilder,
-    WaterBuckBuilder,
+    ConstantVaporPressureBuilder,
+    AntoineVaporPressureBuilder,
+    ClausiusClapeyronVaporPressureBuilder,
+    SaturationConcentrationVaporPressureBuilder,
+    WaterBuckVaporPressureBuilder,
 )
 from particula.gas.vapor_pressure_strategies import (
     ConstantVaporPressureStrategy,
@@ -22,10 +23,11 @@ from particula.gas.vapor_pressure_strategies import (
 class VaporPressureFactory(
     StrategyFactoryABC[
         Union[
-            ConstantBuilder,
-            AntoineBuilder,
-            ClausiusClapeyronBuilder,
-            WaterBuckBuilder,
+            ConstantVaporPressureBuilder,
+            AntoineVaporPressureBuilder,
+            ClausiusClapeyronVaporPressureBuilder,
+            SaturationConcentrationVaporPressureBuilder,
+            WaterBuckVaporPressureBuilder,
         ],
         Union[
             ConstantVaporPressureStrategy,
@@ -76,10 +78,12 @@ class VaporPressureFactory(
 
         Returns:
             dict:
-                - "constant": ConstantBuilder
-                - "antoine": AntoineBuilder
-                - "clausius_clapeyron": ClausiusClapeyronBuilder
-                - "water_buck": WaterBuckBuilder
+                - "constant": ConstantVaporPressureBuilder
+                - "antoine": AntoineVaporPressureBuilder
+                - "clausius_clapeyron": ClausiusClapeyronVaporPressureBuilder
+                - "saturation_concentration": SaturationConcentration
+                  VaporPressureBuilder
+                - "water_buck": WaterBuckVaporPressureBuilder
 
         Examples:
             ```py
@@ -90,8 +94,11 @@ class VaporPressureFactory(
             ```
         """
         return {
-            "constant": ConstantBuilder(),
-            "antoine": AntoineBuilder(),
-            "clausius_clapeyron": ClausiusClapeyronBuilder(),
-            "water_buck": WaterBuckBuilder(),
+            "constant": ConstantVaporPressureBuilder(),
+            "antoine": AntoineVaporPressureBuilder(),
+            "clausius_clapeyron": ClausiusClapeyronVaporPressureBuilder(),
+            "saturation_concentration": (
+                SaturationConcentrationVaporPressureBuilder()
+            ),
+            "water_buck": WaterBuckVaporPressureBuilder(),
         }


### PR DESCRIPTION
The old vapor pressure builder names did not conform to our clear naming pattern.
`ConstantVaporPressureStrategy` had a builder called `ConstantBuilder`. Kinda confusing when accessing from the api, `par.gas.ConstantBuilder`
- Expanded these names to be like `ConstantVaporPressureBuilder`
- Added `SaturationConcentrationVaporPressureBuilder`, which converts a Csat to a constant vapor pressure.

The user docs will be update in #728

## Summary by Sourcery

Improve vapor pressure builder naming and add a new builder for saturation concentration vapor pressure calculation

New Features:
- Added SaturationConcentrationVaporPressureBuilder to convert saturation concentration to vapor pressure

Enhancements:
- Renamed vapor pressure builders to have more consistent and clear names
- Updated builder classes to follow a more descriptive naming convention