### PR TITLE
Refactor mass transfer

### DIFF
--- a/particula/dynamics/condensation/mass_transfer.py
+++ b/particula/dynamics/condensation/mass_transfer.py
@@ -366,8 +366,8 @@ def get_mass_transfer_of_single_species(
     total_requested_mass = mass_to_change.sum()
 
     # 2. Condensation – keep Σ ≤ gas_mass
-    if total_requested_mass > gas_mass[0]:
-        scale = gas_mass[0] / total_requested_mass
+    if total_requested_mass > gas_mass.item():
+        scale = gas_mass.item() / total_requested_mass
         mass_to_change *= scale
 
     # 3. Evaporation – keep Σ ≤ total particle inventory

--- a/particula/dynamics/condensation/tests/mass_transfer_test.py
+++ b/particula/dynamics/condensation/tests/mass_transfer_test.py
@@ -1,7 +1,6 @@
 """Test the Condensation module."""
 
 import numpy as np
-import pytest
 from particula.dynamics.condensation.mass_transfer import (
     get_first_order_mass_transport_k,
     get_mass_transfer_rate,


### PR DESCRIPTION
Mass transfer for evaporation limit was not right.
The implementation was a bit over complicated. 

Both are corrected here.

Fixes #742 

## Summary by Sourcery

Refactor mass transfer routines to simplify their logic and enforce correct inventory limits for both evaporation and condensation; update unit tests to validate uniform down-scaling and per-bin clipping across single and multiple species scenarios.

Bug Fixes:
- Enforce that total evaporation never exceeds the particle inventory and no bin evaporates more than it owns.
- Ensure condensation transfers are properly scaled so total transfer does not exceed available gas mass.

Enhancements:
- Simplify get_mass_transfer_of_single_species and get_mass_transfer_of_multiple_species into a structured four-step process with unified scaling and clipping logic.
- Clean up internal docstrings and comments to clearly describe each algorithm step.

Tests:
- Revise and expand unit tests to cover single and multiple species evaporation and condensation, verifying uniform down-scaling, inventory limits, and per-bin clipping scenarios.