### PR TITLE
Add temperature conversion test

### DIFF
--- a/particula/util/tests/units_test.py
+++ b/particula/util/tests/units_test.py
@@ -43,3 +43,13 @@ class TestUnitConversion(unittest.TestCase):
             self.assertAlmostEqual(result, 1e-9)
         else:
             self.skipTest("Pint not installed. Skipping conversion test.")
+
+    def test_temperature_conversion(self) -> None:
+        """
+        Test temperature conversion from Celsius to Fahrenheit
+        """
+        if IS_PINT_AVAILABE:
+            result = get_unit_conversion("degC", "degF", value=0)
+            self.assertEqual(result, 32.0)
+        else:
+            self.skipTest("Pint not installed. Skipping temperature conversion test.")

--- a/particula/util/tests/units_test.py
+++ b/particula/util/tests/units_test.py
@@ -9,9 +9,9 @@ from particula.util.convert_units import get_unit_conversion
 try:
     import pint  # pylint: disable=unused-import
 except ImportError:
-    IS_PINT_AVAILABE = False
+    IS_PINT_AVAILABLE = False
 else:
-    IS_PINT_AVAILABE = True
+    IS_PINT_AVAILABLE = True
 
 
 class TestUnitConversion(unittest.TestCase):
@@ -28,7 +28,7 @@ class TestUnitConversion(unittest.TestCase):
         """
         Test for import warning if pint is not installed
         """
-        if not IS_PINT_AVAILABE:
+        if not IS_PINT_AVAILABLE:
             with self.assertRaises(ImportError):
                 get_unit_conversion("degC", "degF")
         else:
@@ -38,7 +38,7 @@ class TestUnitConversion(unittest.TestCase):
         """
         Test for example conversion when pint is installed
         """
-        if IS_PINT_AVAILABE:
+        if IS_PINT_AVAILABLE:
             result = get_unit_conversion("ug/m^3", "kg/m^3")
             self.assertAlmostEqual(result, 1e-9)
         else:
@@ -48,7 +48,7 @@ class TestUnitConversion(unittest.TestCase):
         """
         Test temperature conversion from Celsius to Fahrenheit
         """
-        if IS_PINT_AVAILABE:
+        if IS_PINT_AVAILABLE:
             result = get_unit_conversion("degC", "degF", value=0)
             self.assertEqual(result, 32.0)
         else:


### PR DESCRIPTION
## Summary
- extend unit tests to cover Celsius to Fahrenheit conversions


------
https://chatgpt.com/codex/tasks/task_e_6842413ea0588322b3b8dee2b5694718

## Summary by Sourcery

Add a new unit test for temperature conversion from Celsius to Fahrenheit in the units_test.py suite

Enhancements:
- Extend unit tests to cover Celsius to Fahrenheit conversions

Tests:
- Add test_temperature_conversion to verify get_unit_conversion("degC", "degF") returns 32.0 when pint is available
- Skip the temperature conversion test if pint is not installed

## Summary by Sourcery

Tests:
- Add test_temperature_conversion to verify conversion from Celsius to Fahrenheit and skip if pint is unavailable.