### PR TITLE
Add wall loss runnable

### DIFF
--- a/particula/dynamics/__init__.py
+++ b/particula/dynamics/__init__.py
@@ -15,10 +15,12 @@ from particula.dynamics.wall_loss import (
     get_rectangle_wall_loss_rate,
     get_spherical_wall_loss_rate,
 )
+from particula.dynamics.wall_loss_strategy import WallLossStrategy
 
 from particula.dynamics.particle_process import (
     MassCondensation,
     Coagulation,
+    WallLoss,
 )
 
 # particula.dynamics.properties

--- a/particula/dynamics/tests/wall_loss_runnable_test.py
+++ b/particula/dynamics/tests/wall_loss_runnable_test.py
@@ -1,0 +1,59 @@
+"""Tests for the WallLoss runnable process."""
+
+import unittest
+import numpy as np
+
+from particula.particles import PresetParticleRadiusBuilder
+from particula.gas import (
+    AtmosphereBuilder,
+    GasSpeciesBuilder,
+    ConstantVaporPressureStrategy,
+)
+from particula.aerosol import Aerosol
+from particula.dynamics.wall_loss_strategy import WallLossStrategy
+from particula.dynamics.particle_process import WallLoss
+
+
+class TestWallLossRunnable(unittest.TestCase):
+    """Verify wall loss process modifies aerosol particles."""
+
+    def setUp(self):
+        particle = PresetParticleRadiusBuilder().build()
+        gas = (
+            GasSpeciesBuilder()
+            .set_name("air")
+            .set_molar_mass(0.029, "kg/mol")
+            .set_vapor_pressure_strategy(ConstantVaporPressureStrategy(0.0))
+            .set_partitioning(True)
+            .set_concentration(1.0, "kg/m^3")
+            .build()
+        )
+        atmosphere = (
+            AtmosphereBuilder()
+            .set_temperature(298.15, "K")
+            .set_pressure(101325.0, "Pa")
+            .set_more_partitioning_species(gas)
+            .build()
+        )
+        self.aerosol = Aerosol(atmosphere=atmosphere, particles=particle)
+        self.strategy = WallLossStrategy(
+            wall_eddy_diffusivity=0.1,
+            chamber_radius=1.0,
+        )
+        self.process = WallLoss(self.strategy)
+
+    def test_execute_updates_particles(self):
+        """Execute should apply concentration change."""
+        rate = self.strategy.rate(
+            particle=self.aerosol.particles,
+            temperature=self.aerosol.atmosphere.temperature,
+            pressure=self.aerosol.atmosphere.total_pressure,
+        )
+        initial = self.aerosol.particles.get_concentration().copy()
+        updated = self.process.execute(self.aerosol, time_step=2.0)
+        expected = initial + rate * 2.0
+        np.testing.assert_allclose(updated.particles.get_concentration(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/particula/dynamics/tests/wall_loss_strategy_test.py
+++ b/particula/dynamics/tests/wall_loss_strategy_test.py
@@ -1,0 +1,60 @@
+"""Tests for WallLossStrategy."""
+
+import unittest
+import numpy as np
+
+from particula.particles import PresetParticleRadiusBuilder
+from particula.dynamics.wall_loss_strategy import WallLossStrategy
+from particula.dynamics.wall_loss import get_spherical_wall_loss_rate
+
+
+class TestWallLossStrategy(unittest.TestCase):
+    """Test the wall loss strategy class."""
+
+    def setUp(self):
+        self.particle = PresetParticleRadiusBuilder().build()
+        self.strategy = WallLossStrategy(
+            wall_eddy_diffusivity=0.1,
+            chamber_radius=1.0,
+        )
+        self.temperature = 298.15
+        self.pressure = 101325.0
+
+    def test_rate_matches_function(self):
+        """Rate should match helper function."""
+        expected = get_spherical_wall_loss_rate(
+            wall_eddy_diffusivity=0.1,
+            particle_radius=self.particle.get_radius(),
+            particle_density=self.particle.get_density(),
+            particle_concentration=self.particle.get_concentration(),
+            temperature=self.temperature,
+            pressure=self.pressure,
+            chamber_radius=1.0,
+        )
+        result = self.strategy.rate(
+            particle=self.particle,
+            temperature=self.temperature,
+            pressure=self.pressure,
+        )
+        np.testing.assert_allclose(result, expected)
+
+    def test_step_updates_concentration(self):
+        """Step should modify particle concentration."""
+        rate = self.strategy.rate(
+            particle=self.particle,
+            temperature=self.temperature,
+            pressure=self.pressure,
+        )
+        initial = self.particle.get_concentration().copy()
+        self.strategy.step(
+            particle=self.particle,
+            temperature=self.temperature,
+            pressure=self.pressure,
+            time_step=10.0,
+        )
+        expected = initial + rate * 10.0
+        np.testing.assert_allclose(self.particle.get_concentration(), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/particula/dynamics/wall_loss_strategy.py
+++ b/particula/dynamics/wall_loss_strategy.py
@@ -1,0 +1,69 @@
+"""Wall loss strategy module."""
+
+from typing import Optional, Tuple, Union
+import numpy as np
+from numpy.typing import NDArray
+
+from particula.particles.representation import ParticleRepresentation
+from particula.dynamics import wall_loss
+
+
+class WallLossStrategy:
+    """Strategy class for chamber wall loss calculations."""
+
+    def __init__(
+        self,
+        wall_eddy_diffusivity: float,
+        chamber_radius: Optional[float] = None,
+        chamber_dimensions: Optional[Tuple[float, float, float]] = None,
+    ) -> None:
+        if chamber_radius is None and chamber_dimensions is None:
+            raise ValueError(
+                "Either chamber_radius or chamber_dimensions must be provided."
+            )
+        self.wall_eddy_diffusivity = wall_eddy_diffusivity
+        self.chamber_radius = chamber_radius
+        self.chamber_dimensions = chamber_dimensions
+
+    def rate(
+        self,
+        particle: ParticleRepresentation,
+        temperature: float,
+        pressure: float,
+    ) -> Union[float, NDArray[np.float64]]:
+        """Return the wall loss rate for the particle population."""
+        if self.chamber_radius is not None:
+            return wall_loss.get_spherical_wall_loss_rate(
+                wall_eddy_diffusivity=self.wall_eddy_diffusivity,
+                particle_radius=particle.get_radius(),
+                particle_density=particle.get_density(),
+                particle_concentration=particle.get_concentration(),
+                temperature=temperature,
+                pressure=pressure,
+                chamber_radius=self.chamber_radius,
+            )
+        return wall_loss.get_rectangle_wall_loss_rate(
+            wall_eddy_diffusivity=self.wall_eddy_diffusivity,
+            particle_radius=particle.get_radius(),
+            particle_density=particle.get_density(),
+            particle_concentration=particle.get_concentration(),
+            temperature=temperature,
+            pressure=pressure,
+            chamber_dimensions=self.chamber_dimensions,  # type: ignore
+        )
+
+    def step(
+        self,
+        particle: ParticleRepresentation,
+        temperature: float,
+        pressure: float,
+        time_step: float,
+    ) -> ParticleRepresentation:
+        """Advance particle concentration by one time step."""
+        rate = self.rate(
+            particle=particle,
+            temperature=temperature,
+            pressure=pressure,
+        )
+        particle.add_concentration(rate * time_step)
+        return particle


### PR DESCRIPTION
## Summary
- create `WallLossStrategy` and use it in new `WallLoss` runnable
- export wall loss classes in dynamics package
- add unit tests for strategy and runnable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684246d43c088322b4aa52fe805cf957