### PR TITLE
Add tests for convert dtype helpers

### DIFF
--- a/particula/util/convert_dtypes.py
+++ b/particula/util/convert_dtypes.py
@@ -10,8 +10,8 @@ To be removed, likely particula_beta only. -kyle
 """
 
 from typing import Any, Dict, List
-import numpy as np
 from collections.abc import Sequence
+import numpy as np
 
 
 def get_coerced_type(data, dtype):

--- a/particula/util/convert_dtypes.py
+++ b/particula/util/convert_dtypes.py
@@ -79,7 +79,8 @@ def get_dict_from_list(list_of_str: list) -> dict:
         # {'alpha': 0, 'beta': 1, 'gamma': 2}
         ```
     """
-    assert all(list_of_str), "Input list_of_str must not be empty."
+    assert list_of_str, "Input list_of_str must not be empty."
+    assert all(list_of_str), "Input list_of_str must not contain empty strings."
     assert all(
         isinstance(item, str) for item in list_of_str
     ), "Input \

--- a/particula/util/convert_dtypes.py
+++ b/particula/util/convert_dtypes.py
@@ -11,6 +11,7 @@ To be removed, likely particula_beta only. -kyle
 
 from typing import Any, Dict, List
 import numpy as np
+from collections.abc import Sequence
 
 
 def get_coerced_type(data, dtype):
@@ -79,12 +80,13 @@ def get_dict_from_list(list_of_str: list) -> dict:
         # {'alpha': 0, 'beta': 1, 'gamma': 2}
         ```
     """
-    if not list_of_str:
-        raise ValueError("Input list_of_str must not be empty.")
-    if not all(list_of_str):
-        raise ValueError("Input list_of_str must not contain empty strings.")
-    if not all(isinstance(item, str) for item in list_of_str):
-        raise TypeError("Input list_of_str must contain only strings.")
+    # basic type / emptiness check
+    if not isinstance(list_of_str, Sequence) or not list_of_str:
+        raise ValueError("list_of_str must be a non-empty sequence of strings.")
+
+    # one pass: ensure every element is a non-empty string
+    if any(not isinstance(item, str) or item == "" for item in list_of_str):
+        raise TypeError("All elements in list_of_str must be non-empty strings.")
 
     # Create a dictionary from the list of strings using a dictionary
     # comprehension

--- a/particula/util/convert_dtypes.py
+++ b/particula/util/convert_dtypes.py
@@ -82,11 +82,15 @@ def get_dict_from_list(list_of_str: list) -> dict:
     """
     # basic type / emptiness check
     if not isinstance(list_of_str, Sequence) or not list_of_str:
-        raise ValueError("list_of_str must be a non-empty sequence of strings.")
+        raise ValueError(
+            "list_of_str must be a non-empty sequence of strings."
+        )
 
     # one pass: ensure every element is a non-empty string
     if any(not isinstance(item, str) or item == "" for item in list_of_str):
-        raise TypeError("All elements in list_of_str must be non-empty strings.")
+        raise TypeError(
+            "All elements in list_of_str must be non-empty strings."
+        )
 
     # Create a dictionary from the list of strings using a dictionary
     # comprehension

--- a/particula/util/convert_dtypes.py
+++ b/particula/util/convert_dtypes.py
@@ -82,9 +82,7 @@ def get_dict_from_list(list_of_str: list) -> dict:
     """
     # basic type / emptiness check
     if not isinstance(list_of_str, Sequence) or not list_of_str:
-        raise TypeError(
-            "list_of_str must be a non-empty sequence of strings."
-        )
+        raise TypeError("list_of_str must be a non-empty sequence of strings.")
 
     # one pass: ensure every element is a non-empty string
     if any(not isinstance(item, str) or item == "" for item in list_of_str):

--- a/particula/util/convert_dtypes.py
+++ b/particula/util/convert_dtypes.py
@@ -79,12 +79,12 @@ def get_dict_from_list(list_of_str: list) -> dict:
         # {'alpha': 0, 'beta': 1, 'gamma': 2}
         ```
     """
-    assert list_of_str, "Input list_of_str must not be empty."
-    assert all(list_of_str), "Input list_of_str must not contain empty strings."
-    assert all(
-        isinstance(item, str) for item in list_of_str
-    ), "Input \
-        list_of_str must contain only strings."
+    if not list_of_str:
+        raise ValueError("Input list_of_str must not be empty.")
+    if not all(list_of_str):
+        raise ValueError("Input list_of_str must not contain empty strings.")
+    if not all(isinstance(item, str) for item in list_of_str):
+        raise TypeError("Input list_of_str must contain only strings.")
 
     # Create a dictionary from the list of strings using a dictionary
     # comprehension

--- a/particula/util/convert_dtypes.py
+++ b/particula/util/convert_dtypes.py
@@ -68,7 +68,7 @@ def get_dict_from_list(list_of_str: list) -> dict:
         - A dict where keys are the strings and values are their indices.
 
     Raises:
-        - AssertionError : If the list is empty or contains non-string items.
+        - TypeError : If the list is empty or contains non-string items.
 
     Examples:
         ``` py title="Convert list of strings to dictionary"
@@ -82,7 +82,7 @@ def get_dict_from_list(list_of_str: list) -> dict:
     """
     # basic type / emptiness check
     if not isinstance(list_of_str, Sequence) or not list_of_str:
-        raise ValueError(
+        raise TypeError(
             "list_of_str must be a non-empty sequence of strings."
         )
 

--- a/particula/util/tests/convert_dtypes_test.py
+++ b/particula/util/tests/convert_dtypes_test.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pytest
+
+from particula.util.convert_dtypes import (
+    get_coerced_type,
+    get_dict_from_list,
+    get_values_of_dict,
+    get_shape_check,
+)
+
+
+def test_get_coerced_type_success():
+    """Scalar and array coercion succeed."""
+    assert get_coerced_type(1, float) == 1.0
+    array = get_coerced_type([1, 2, 3], np.ndarray)
+    assert isinstance(array, np.ndarray)
+    assert np.array_equal(array, np.array([1, 2, 3]))
+    arr = np.array([1])
+    # already ndarray should return same object
+    assert get_coerced_type(arr, np.ndarray) is arr
+
+
+def test_get_coerced_type_failure():
+    """Invalid coercion raises ValueError."""
+    with pytest.raises(ValueError):
+        get_coerced_type("abc", int)
+
+
+def test_get_dict_from_list_valid():
+    """List of strings converted to expected dict."""
+    assert get_dict_from_list(["a", "b", "c"]) == {"a": 0, "b": 1, "c": 2}
+
+
+def test_get_dict_from_list_invalid():
+    """Empty or non-string lists raise AssertionError."""
+    with pytest.raises(AssertionError):
+        get_dict_from_list([])
+    with pytest.raises(AssertionError):
+        get_dict_from_list(["a", 1])
+
+
+def test_get_values_of_dict_success_and_failure():
+    """Extract values by keys or raise for missing key."""
+    mapping = {"a": 1, "b": 2, "c": 3}
+    assert get_values_of_dict(["b", "a"], mapping) == [2, 1]
+    with pytest.raises(KeyError):
+        get_values_of_dict(["d"], mapping)
+
+
+def test_get_shape_check_1d():
+    """1-D data are expanded to 2-D when header has one item."""
+    time = np.arange(3)
+    data = np.array([1, 2, 3])
+    result = get_shape_check(time, data, ["x"])
+    assert result.shape == (3, 1)
+    assert np.array_equal(result[:, 0], data)
+    with pytest.raises(ValueError):
+        get_shape_check(time, data, ["x", "y"])
+
+
+def test_get_shape_check_2d_and_header():
+    """2-D data reshaping and header validation."""
+    time = np.arange(3)
+    data = np.array([[1, 2, 3], [4, 5, 6]])  # shape (2, 3)
+    reshaped = get_shape_check(time, data, ["a", "b"])
+    assert reshaped.shape == (3, 2)
+    assert np.array_equal(reshaped, np.array([[1, 4], [2, 5], [3, 6]]))
+    with pytest.raises(ValueError):
+        get_shape_check(time, np.ones((3, 2)), ["only_one"])
+    with pytest.raises(ValueError):
+        get_shape_check(time, np.ones((3, 3)), ["a", "b"])

--- a/particula/util/tests/convert_dtypes_test.py
+++ b/particula/util/tests/convert_dtypes_test.py
@@ -36,9 +36,9 @@ def test_get_dict_from_list_valid():
 
 def test_get_dict_from_list_invalid():
     """Empty or non-string lists raise AssertionError."""
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         get_dict_from_list([])
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         get_dict_from_list(["a", 1])
 
 

--- a/particula/util/tests/convert_dtypes_test.py
+++ b/particula/util/tests/convert_dtypes_test.py
@@ -1,6 +1,7 @@
 """
 Unit tests for the convert_dtypes module.
 """
+
 import numpy as np
 import pytest
 

--- a/particula/util/tests/convert_dtypes_test.py
+++ b/particula/util/tests/convert_dtypes_test.py
@@ -1,3 +1,6 @@
+"""
+Unit tests for the convert_dtypes module.
+"""
 import numpy as np
 import pytest
 


### PR DESCRIPTION
## Summary
- add comprehensive tests for conversion helpers
- fix empty-list handling in `get_dict_from_list`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842dce899688322a3efd0e5dc28c889

## Summary by Sourcery

Add comprehensive unit tests for conversion helpers and fix empty-list assertion logic in get_dict_from_list

Bug Fixes:
- Refine empty-list handling in get_dict_from_list to assert non-empty list and non-empty strings separately.

Tests:
- Add unit tests for conversion helpers: get_coerced_type, get_dict_from_list, get_values_of_dict, and get_shape_check.