### PR TITLE
Skip partitioning indices

### DIFF
--- a/particula/dynamics/condensation/condensation_strategies.py
+++ b/particula/dynamics/condensation/condensation_strategies.py
@@ -309,9 +309,6 @@ class CondensationStrategy(ABC):
             kelvin_term=kelvin_term,
         )
 
-    # ------------------------------------------------------------------
-    # helper
-    # ------------------------------------------------------------------
     def _apply_skip_partitioning(
         self, array: NDArray[np.float64]
     ) -> NDArray[np.float64]:
@@ -319,16 +316,12 @@ class CondensationStrategy(ABC):
         Zero-out entries for species indices that are configured NOT to
         partition/condense.
 
-        Arguments
-        ---------
-        array : ndarray
-            1-D or 2-D array whose elements correspond to gas-species order
-            used by this strategy.
+        Arguments:
+            - array : 1-D or 2-D array whose elements correspond to gas-species
+              order used by this strategy.
 
-        Returns
-        -------
-        ndarray
-            Same array object with the chosen columns / elements set to zero.
+        Returns:
+            - Same array object with the chosen columns / elements set to zero.
         """
         if self.skip_partitioning_indices is None:
             return array

--- a/particula/dynamics/condensation/tests/condensation_strategies_test.py
+++ b/particula/dynamics/condensation/tests/condensation_strategies_test.py
@@ -10,6 +10,9 @@ from particula.dynamics.condensation.condensation_strategies import (
 from particula.particles.representation import ParticleRepresentation
 from particula.gas.species import GasSpecies
 
+import numpy as np                       # new
+from unittest.mock import patch          # new
+
 
 # pylint: disable=too-many-instance-attributes
 class TestCondensationIsothermal(unittest.TestCase):
@@ -32,6 +35,11 @@ class TestCondensationIsothermal(unittest.TestCase):
         self.temperature = 298.15  # K
         self.pressure = 101325  # Pa
         self.time_step = 1.0  # s
+
+        self.particle.concentration = 1.0        # new – scalar concentration
+        self.particle.get_radius.return_value = np.array([1e-9])  # new – default radius
+        self.particle.get_species_mass.return_value = np.array([1.0])  # new dummy mass
+        self.particle.surface.kelvin_term.return_value = np.array([1.0])  # new
 
     def test_mean_free_path(self):
         """Test the mean free path call."""
@@ -57,3 +65,58 @@ class TestCondensationIsothermal(unittest.TestCase):
             pressure=self.pressure,
         )
         self.assertIsNotNone(result)
+
+    def test_fill_zero_radius(self):
+        """_fill_zero_radius changes zeros to max radius."""
+        radii = np.array([0.0, 1e-9, 2e-9])
+        filled = self.strategy._fill_zero_radius(radii.copy())
+        # zero should become the maximum original non-zero radius (2 nm)
+        self.assertTrue(np.all(filled != 0.0))
+        self.assertEqual(filled[0], np.max(radii))
+
+    def test_rate_respects_skip_indices(self):
+        """Chosen indices must be zeroed in the returned rate."""
+        strategy_skip = CondensationIsothermal(
+            molar_mass=self.molar_mass,
+            diffusion_coefficient=self.diffusion_coefficient,
+            accommodation_coefficient=self.accommodation_coefficient,
+            skip_partitioning_indices=[1],
+        )
+        # fake mass-transfer values (3 “species”)
+        strategy_skip.mass_transfer_rate = MagicMock(return_value=np.array([1.0, 2.0, 3.0]))
+        rates = strategy_skip.rate(
+            particle=self.particle,
+            gas_species=self.gas_species,
+            temperature=self.temperature,
+            pressure=self.pressure,
+        )
+        np.testing.assert_array_equal(rates, np.array([1.0, 0.0, 3.0]))
+
+    def test_step_zeroes_mass_rate_before_transfer(self):
+        """step() must pass a zeroed mass_rate to get_mass_transfer."""
+        strategy_skip = CondensationIsothermal(
+            molar_mass=self.molar_mass,
+            diffusion_coefficient=self.diffusion_coefficient,
+            accommodation_coefficient=self.accommodation_coefficient,
+            skip_partitioning_indices=[1],
+        )
+        # return non-zero values so we can see the zeroing
+        strategy_skip.mass_transfer_rate = MagicMock(return_value=np.array([1.0, 2.0, 3.0]))
+
+        with patch(
+            "particula.dynamics.condensation.condensation_strategies.get_mass_transfer",
+            autospec=True,
+        ) as mocked_get_mass_transfer:
+            mocked_get_mass_transfer.return_value = np.array([0.1, 0.0, 0.3])
+
+            strategy_skip.step(
+                particle=self.particle,
+                gas_species=self.gas_species,
+                temperature=self.temperature,
+                pressure=self.pressure,
+                time_step=self.time_step,
+            )
+
+            # extract the mass_rate argument passed into get_mass_transfer
+            passed_mass_rate = mocked_get_mass_transfer.call_args.kwargs["mass_rate"]
+            np.testing.assert_array_equal(passed_mass_rate, np.array([1.0, 0.0, 3.0]))

--- a/particula/util/tests/validate_inputs_test.py
+++ b/particula/util/tests/validate_inputs_test.py
@@ -69,3 +69,15 @@ def test_valid_finite():
 
     with pytest.raises(ValueError, match="Argument 'x' must be finite."):
         sample_function2(np.nan)
+
+
+def test_none_skips_validation():
+    """Test that None values skip validation."""
+    some_dict3 = {"x": "positive"}
+
+    @validate_inputs(some_dict3)
+    def sample_function3(x=None):
+        """Function that allows None input."""
+        return x
+
+    assert sample_function3(None) is None

--- a/particula/util/validate_inputs.py
+++ b/particula/util/validate_inputs.py
@@ -154,6 +154,8 @@ def validate_inputs(dict_args):
                     raise TypeError(
                         f"Argument '{name}' is not provided and has no default."
                     )
+                if bound.arguments[name] is None:
+                    continue
                 value = np.asarray(bound.arguments[name])
                 if comp == "positive":
                     validate_positive(value, name)

--- a/particula/util/validate_inputs.py
+++ b/particula/util/validate_inputs.py
@@ -116,7 +116,9 @@ def validate_inputs(dict_args):
 
     The constraints are defined by a dictionary of argument names and their
     validation types (e.g., "positive", "negative", "nonnegative", etc.). If
-    any argument violates its constraint, a ValueError is raised.
+    any argument violates its constraint, a ValueError is raised. Arguments
+    explicitly passed as ``None`` are ignored and no validation is performed
+    on them.
 
     Arguments:
         - dict_args : Dictionary {argument_name: constraint_type}, where the


### PR DESCRIPTION

- Added optional input to skip partitioning for select list of species.
- Used for "non-volatile" seeds or things like that.
- expanded tests

Fixes #741
the evaporation limit was fixed in PR # #743

## Summary by Sourcery

Enable selective skipping of species during the condensation process by adding a skip_partitioning_indices parameter, applying it in rate and step computations, and reinforcing behavior with expanded unit tests and updated documentation examples.

New Features:
- Introduce skip_partitioning_indices option to bypass condensation for specified species in condensation strategies.

Enhancements:
- Implement _apply_skip_partitioning helper and integrate skipping logic into rate() and step().
- Add illustrative examples in docstrings for key methods.

Tests:
- Expand condensation strategy tests to cover skipping behavior, zero-radius handling, and realistic particle and gas species setups.

## Summary by Sourcery

Enable selective skipping of species during condensation by adding a skip_partitioning_indices parameter, applying it to rate and step computations, and reinforcing behavior with expanded tests and documentation examples.

New Features:
- Add skip_partitioning_indices option to CondensationStrategy to exclude specified species from condensation

Enhancements:
- Implement _apply_skip_partitioning helper and integrate skip logic into rate() and step() methods
- Include usage examples in docstrings for key methods

Documentation:
- Add illustrative examples in method docstrings for mean_free_path, knudsen_number, first_order_mass_transport, calculate_pressure_delta, rate, and step

Tests:
- Expand condensation strategy tests to cover skipping behavior, zero-radius filling, and 1D/2D array masking