### PR TITLE
Add tests for skip partitioning helper

### DIFF
--- a/particula/dynamics/condensation/tests/condensation_strategies_test.py
+++ b/particula/dynamics/condensation/tests/condensation_strategies_test.py
@@ -200,3 +200,23 @@ class TestCondensationIsothermal(unittest.TestCase):
         self.assertAlmostEqual(
             final_gas_conc[skip_idx], initial_gas_conc[skip_idx]
         )
+
+    def test_apply_skip_partitioning_direct(self):
+        """_apply_skip_partitioning zeroes selected indices on 1D and 2D arrays."""
+        strategy = CondensationIsothermal(
+            molar_mass=self.molar_mass,
+            diffusion_coefficient=self.diffusion_coefficient,
+            accommodation_coefficient=self.accommodation_coefficient,
+            skip_partitioning_indices=[0, 2],
+        )
+
+        array_1d = np.arange(4.0)
+        returned_1d = strategy._apply_skip_partitioning(array_1d)
+        self.assertIs(returned_1d, array_1d)
+        np.testing.assert_array_equal(array_1d, np.array([0.0, 1.0, 0.0, 3.0]))
+
+        array_2d = np.tile(np.arange(4.0), (2, 1))
+        returned_2d = strategy._apply_skip_partitioning(array_2d)
+        self.assertIs(returned_2d, array_2d)
+        expected_2d = np.tile(np.array([0.0, 1.0, 0.0, 3.0]), (2, 1))
+        np.testing.assert_array_equal(array_2d, expected_2d)


### PR DESCRIPTION
## Summary
- add test covering `_apply_skip_partitioning`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6842e7db7608832294cfb3d274828d17

## Summary by Sourcery

Add unit tests for the `_apply_skip_partitioning` helper in the `CondensationIsothermal` strategy to verify that it zeros specified indices on 1D and 2D numpy arrays in place.

Tests:
- Add tests covering `_apply_skip_partitioning` to ensure selected indices are zeroed on 1D arrays and the original array is returned.
- Add tests covering `_apply_skip_partitioning` to ensure selected indices are zeroed on 2D arrays and the original array is returned.