### PR TITLE
Add external PR doc preview deployment

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -53,3 +53,13 @@ jobs:
           uses: rossjrw/pr-preview-action@v1
           with:
             source-dir: site  # Assuming mkdocs build output is the default 'site' directory
+
+        - name: Preview Documentation from fork
+          if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]' }}
+          uses: JamesIves/github-pages-deploy-action@v4
+          with:
+            token: ${{ secrets.PUBLIC_PR_PREVIEW }}
+            repository-name: uncscode/public-pr-preview
+            branch: particula-preview
+            folder: site
+            target-folder: pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  pull_request_target:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -20,8 +23,17 @@ jobs:
       cancel-in-progress: true
     steps:
         - name: Check out code
+          if: github.event_name != 'pull_request_target'
           uses: actions/checkout@v4
-          with: 
+          with:
+            persist-credentials: false
+
+        - name: Check out PR code (pull_request_target)
+          if: github.event_name == 'pull_request_target'
+          uses: actions/checkout@v4
+          with:
+            repository: ${{ github.event.pull_request.head.repo.full_name }}
+            ref: ${{ github.event.pull_request.head.ref }}
             persist-credentials: false
 
         - name: Set up Python 3.12
@@ -49,13 +61,13 @@ jobs:
             folder: site  # Assuming mkdocs build output is the default 'site' directory
 
         - name: Preview Documentation (on PR)
-          if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
+          if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
           uses: rossjrw/pr-preview-action@v1
           with:
             source-dir: site  # Assuming mkdocs build output is the default 'site' directory
 
         - name: Preview Documentation from fork
-          if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]' }}
+          if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]' }}
           uses: JamesIves/github-pages-deploy-action@v4
           with:
             token: ${{ secrets.PUBLIC_PR_PREVIEW }}

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -67,7 +67,7 @@ jobs:
             source-dir: site  # Assuming mkdocs build output is the default 'site' directory
 
         - name: Preview Documentation from fork
-          if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]' }}
+          if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]' && secrets.PUBLIC_PR_PREVIEW != '' }}
           uses: JamesIves/github-pages-deploy-action@v4
           with:
             token: ${{ secrets.PUBLIC_PR_PREVIEW }}


### PR DESCRIPTION
## Summary
- publish doc previews from forked PRs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fc58a97083228d0734fa7f8212a2

## Summary by Sourcery

Enable external PR documentation previews by extending the MkDocs GitHub Actions workflow to handle pull_request_target events, differentiating checkout steps, and deploying built docs for forked PRs to a public preview repository

New Features:
- Publish documentation previews for forked pull requests to a dedicated public repository

Enhancements:
- Trigger the MkDocs workflow on pull_request_target and adjust checkout logic based on PR origin

CI:
- Expand preview conditions to include pull_request_target events alongside pull_request

Deployment:
- Deploy forked PR documentation previews to the uncscode/public-pr-preview repository under pr-{number}