### PR TITLE
Add Colab button to notebooks

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="md-content__button-row">
     {% if page.nb_url %}
-        <a href="https://colab.research.google.com/github/uncscode/particula/blob/main/docs/{{ page.file.src_path }}" title="Open in Google Colab" class="md-content__button md-icon" target="_blank" rel="noopener noreferrer">
+        <a href="https://colab.research.google.com/github/uncscode/particula/blob/main/docs/{{ page.file.src_path }}" title="Open in Google Colab" aria-label="Open this notebook in Google Colab" class="md-content__button md-icon" target="_blank" rel="noopener noreferrer">
             {% include ".icons/material/open-in-new.svg" %}
             Colab
         </a>

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -3,11 +3,11 @@
 {% block content %}
 <div class="md-content__button-row">
     {% if page.nb_url %}
-        <a href="https://colab.research.google.com/github/uncscode/particula/blob/main/docs/{{ page.file.src_path }}" title="Open in Google Colab" class="md-content__button md-icon">
+        <a href="https://colab.research.google.com/github/uncscode/particula/blob/main/docs/{{ page.file.src_path }}" title="Open in Google Colab" class="md-content__button md-icon" target="_blank" rel="noopener noreferrer">
             {% include ".icons/material/open-in-new.svg" %}
             Colab
         </a>
-        <a href="{{ page.nb_url }}" title="Download Notebook" class="md-content__button md-icon">
+        <a href="{{ page.nb_url }}" title="Download Notebook" class="md-content__button md-icon" target="_blank" rel="noopener noreferrer">
             {% include ".icons/material/download.svg" %}
             Notebook
         </a>

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -5,7 +5,7 @@
     {% if page.nb_url %}
         <a href="https://colab.research.google.com/github/uncscode/particula/blob/main/docs/{{ page.file.src_path }}" title="Open in Google Colab" class="md-content__button md-icon">
             {% include ".icons/material/open-in-new.svg" %}
-            Open in Colab
+            Colab
         </a>
         <a href="{{ page.nb_url }}" title="Download Notebook" class="md-content__button md-icon">
             {% include ".icons/material/download.svg" %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,19 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class="md-content__button-row">
+    {% if page.nb_url %}
+        <a href="https://colab.research.google.com/github/uncscode/particula/blob/main/docs/{{ page.file.src_path }}" title="Open in Google Colab" class="md-content__button md-icon">
+            {% include ".icons/material/open-in-new.svg" %}
+            Open in Colab
+        </a>
+        <a href="{{ page.nb_url }}" title="Download Notebook" class="md-content__button md-icon">
+            {% include ".icons/material/download.svg" %}
+            Notebook
+        </a>
+    {% endif %}
+</div>
+
+{{ super() }}
+
+{% endblock content %}


### PR DESCRIPTION
## Summary
- add custom template to display an **Open in Colab** button alongside the notebook download link

## Testing
- `pytest -q`
- `mkdocs build` *(fails: ModuleNotFoundError: No module named 'cairosvg')*

------
https://chatgpt.com/codex/tasks/task_e_684310f56d8883228d325c61d398fcbb

## Summary by Sourcery

New Features:
- Display 'Open in Colab' button alongside the notebook download link when a notebook URL (nb_url) is provided in the page metadata