### PR TITLE
Add condensation builders and factory

### DIFF
--- a/particula/dynamics/__init__.py
+++ b/particula/dynamics/__init__.py
@@ -33,6 +33,12 @@ from particula.dynamics.properties.wall_loss_coefficient import (
 from particula.dynamics.condensation.condensation_strategies import (
     CondensationIsothermal,
 )
+from particula.dynamics.condensation.condensation_builder.condensation_isothermal_builder import (
+    CondensationIsothermalBuilder,
+)
+from particula.dynamics.condensation.condensation_factories import (
+    CondensationFactory,
+)
 from particula.dynamics.condensation.mass_transfer import (
     get_mass_transfer_rate,
     get_first_order_mass_transport_k,

--- a/particula/dynamics/condensation/condensation_builder/condensation_builder_mixin.py
+++ b/particula/dynamics/condensation/condensation_builder/condensation_builder_mixin.py
@@ -1,0 +1,79 @@
+"""Mixin classes for Condensation strategy builders."""
+
+from typing import Optional, Union
+import logging
+
+import numpy as np
+from numpy.typing import NDArray
+
+from particula.util.validate_inputs import validate_inputs
+from particula.util.convert_units import get_unit_conversion
+
+logger = logging.getLogger("particula")
+
+
+class BuilderDiffusionCoefficientMixin:
+    """Mixin to set a diffusion coefficient in m^2/s."""
+
+    def __init__(self) -> None:
+        self.diffusion_coefficient: Optional[
+            Union[float, NDArray[np.float64]]
+        ] = None
+
+    @validate_inputs({"diffusion_coefficient": "positive"})
+    def set_diffusion_coefficient(
+        self,
+        diffusion_coefficient: Union[float, NDArray[np.float64]],
+        diffusion_coefficient_units: str,
+    ):
+        """Set the diffusion coefficient for the condensing species."""
+        if diffusion_coefficient_units == "m^2/s":
+            self.diffusion_coefficient = diffusion_coefficient
+            return self
+        self.diffusion_coefficient = (
+            diffusion_coefficient
+            * get_unit_conversion(
+                diffusion_coefficient_units,
+                "m^2/s",
+            )
+        )
+        return self
+
+
+class BuilderAccommodationCoefficientMixin:
+    """Mixin to set the mass accommodation coefficient."""
+
+    def __init__(self) -> None:
+        self.accommodation_coefficient: Optional[
+            Union[float, NDArray[np.float64]]
+        ] = None
+
+    @validate_inputs({"accommodation_coefficient": "nonnegative"})
+    def set_accommodation_coefficient(
+        self,
+        accommodation_coefficient: Union[float, NDArray[np.float64]],
+        accommodation_coefficient_units: Optional[str] = None,
+    ):
+        """Set the dimensionless mass accommodation coefficient."""
+        if accommodation_coefficient_units is not None:
+            logger.warning(
+                "Ignoring units for accommodation coefficient parameter."
+            )
+        self.accommodation_coefficient = accommodation_coefficient
+        return self
+
+
+class BuilderUpdateGasesMixin:
+    """Mixin to specify whether the gas phase should be updated."""
+
+    def __init__(self) -> None:
+        self.update_gases: bool = True
+
+    def set_update_gases(
+        self, update_gases: bool, update_gases_units: Optional[str] = None
+    ):
+        """Set the flag controlling gas-phase updates."""
+        if update_gases_units is not None:
+            logger.warning("Ignoring units for update_gases parameter.")
+        self.update_gases = bool(update_gases)
+        return self

--- a/particula/dynamics/condensation/condensation_builder/condensation_isothermal_builder.py
+++ b/particula/dynamics/condensation/condensation_builder/condensation_isothermal_builder.py
@@ -1,0 +1,45 @@
+"""Builder for the CondensationIsothermal strategy."""
+
+from particula.abc_builder import BuilderABC
+from particula.builder_mixin import BuilderMolarMassMixin
+from particula.dynamics.condensation.condensation_strategies import (
+    CondensationStrategy,
+    CondensationIsothermal,
+)
+from particula.dynamics.condensation.condensation_builder.condensation_builder_mixin import (
+    BuilderDiffusionCoefficientMixin,
+    BuilderAccommodationCoefficientMixin,
+    BuilderUpdateGasesMixin,
+)
+
+
+class CondensationIsothermalBuilder(
+    BuilderABC,
+    BuilderMolarMassMixin,
+    BuilderDiffusionCoefficientMixin,
+    BuilderAccommodationCoefficientMixin,
+    BuilderUpdateGasesMixin,
+):
+    """Fluent builder for :class:`CondensationIsothermal`."""
+
+    def __init__(self) -> None:
+        required_parameters = [
+            "molar_mass",
+            "diffusion_coefficient",
+            "accommodation_coefficient",
+        ]
+        BuilderABC.__init__(self, required_parameters)
+        BuilderMolarMassMixin.__init__(self)
+        BuilderDiffusionCoefficientMixin.__init__(self)
+        BuilderAccommodationCoefficientMixin.__init__(self)
+        BuilderUpdateGasesMixin.__init__(self)
+
+    def build(self) -> CondensationStrategy:
+        """Validate parameters and create a condensation strategy."""
+        self.pre_build_check()
+        return CondensationIsothermal(
+            molar_mass=self.molar_mass,
+            diffusion_coefficient=self.diffusion_coefficient,
+            accommodation_coefficient=self.accommodation_coefficient,
+            update_gases=self.update_gases,
+        )

--- a/particula/dynamics/condensation/condensation_builder/tests/condensation_builder_mixin_test.py
+++ b/particula/dynamics/condensation/condensation_builder/tests/condensation_builder_mixin_test.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pytest
+
+from particula.dynamics.condensation.condensation_builder.condensation_builder_mixin import (
+    BuilderDiffusionCoefficientMixin,
+    BuilderAccommodationCoefficientMixin,
+    BuilderUpdateGasesMixin,
+)
+
+
+class MixinTester(
+    BuilderDiffusionCoefficientMixin,
+    BuilderAccommodationCoefficientMixin,
+    BuilderUpdateGasesMixin,
+):
+    """Simple class to test condensation builder mixins."""
+
+
+def test_set_diffusion_coefficient_units():
+    tester = MixinTester()
+    tester.set_diffusion_coefficient(1.0, "cm^2/s")
+    assert pytest.approx(tester.diffusion_coefficient) == 1.0e-4
+
+
+def test_set_accommodation_coefficient():
+    tester = MixinTester()
+    tester.set_accommodation_coefficient(0.5)
+    assert tester.accommodation_coefficient == pytest.approx(0.5)
+
+
+def test_set_update_gases():
+    tester = MixinTester()
+    tester.set_update_gases(False)
+    assert tester.update_gases is False

--- a/particula/dynamics/condensation/condensation_builder/tests/condensation_isothermal_builder_test.py
+++ b/particula/dynamics/condensation/condensation_builder/tests/condensation_isothermal_builder_test.py
@@ -1,0 +1,21 @@
+import pytest
+
+from particula.dynamics import (
+    CondensationIsothermalBuilder,
+    CondensationIsothermal,
+)
+
+
+def test_build_with_valid_parameters():
+    builder = CondensationIsothermalBuilder()
+    builder.set_molar_mass(0.018, "kg/mol")
+    builder.set_diffusion_coefficient(2e-5, "m^2/s")
+    builder.set_accommodation_coefficient(1.0)
+    strategy = builder.build()
+    assert isinstance(strategy, CondensationIsothermal)
+
+
+def test_build_missing_required_parameters():
+    builder = CondensationIsothermalBuilder()
+    with pytest.raises(ValueError):
+        builder.build()

--- a/particula/dynamics/condensation/condensation_factories.py
+++ b/particula/dynamics/condensation/condensation_factories.py
@@ -1,0 +1,20 @@
+"""Factory for building condensation strategies."""
+
+from typing import Dict, Any
+
+from particula.abc_factory import StrategyFactoryABC
+from particula.dynamics.condensation.condensation_builder.condensation_isothermal_builder import (
+    CondensationIsothermalBuilder,
+)
+from particula.dynamics.condensation.condensation_strategies import (
+    CondensationStrategy,
+)
+
+
+class CondensationFactory(
+    StrategyFactoryABC[CondensationIsothermalBuilder, CondensationStrategy]
+):
+    """Factory class for condensation strategies."""
+
+    def get_builders(self) -> Dict[str, Any]:
+        return {"isothermal": CondensationIsothermalBuilder()}

--- a/particula/dynamics/condensation/tests/condensation_factories_test.py
+++ b/particula/dynamics/condensation/tests/condensation_factories_test.py
@@ -1,0 +1,27 @@
+import pytest
+
+from particula.dynamics import (
+    CondensationFactory,
+    CondensationIsothermal,
+)
+
+
+def test_isothermal_condensation():
+    factory = CondensationFactory()
+    strategy = factory.get_strategy(
+        "isothermal",
+        {
+            "molar_mass": 0.018,
+            "molar_mass_units": "kg/mol",
+            "diffusion_coefficient": 2e-5,
+            "diffusion_coefficient_units": "m^2/s",
+            "accommodation_coefficient": 1.0,
+        },
+    )
+    assert isinstance(strategy, CondensationIsothermal)
+
+
+def test_invalid_condensation_strategy():
+    factory = CondensationFactory()
+    with pytest.raises(ValueError):
+        factory.get_strategy("nonexistent", {})


### PR DESCRIPTION
## Summary
- add mixins and builder for condensation strategies
- add condensation factory
- expose new components in `dynamics.__init__`
- test new mixins, builder, and factory

## Testing
- `pytest -q -Werror`
- `flake8 . --config .github/.flake8`


------
https://chatgpt.com/codex/tasks/task_e_684311475d2c8322a8f6ab4c48b7715c