### PR TITLE
Test build from fork

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -53,3 +53,13 @@ jobs:
           uses: rossjrw/pr-preview-action@v1
           with:
             source-dir: site  # Assuming mkdocs build output is the default 'site' directory
+
+        - name: Preview Documentation from fork
+          if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]' }}
+          uses: JamesIves/github-pages-deploy-action@v4
+          with:
+            token: ${{ secrets.PUBLIC_PR_PREVIEW }}
+            repository-name: uncscode/public-pr-preview
+            branch: particula-preview
+            folder: site
+            target-folder: pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  pull_request_target:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -20,8 +23,17 @@ jobs:
       cancel-in-progress: true
     steps:
         - name: Check out code
+          if: github.event_name != 'pull_request_target'
           uses: actions/checkout@v4
-          with: 
+          with:
+            persist-credentials: false
+
+        - name: Check out PR code (pull_request_target)
+          if: github.event_name == 'pull_request_target'
+          uses: actions/checkout@v4
+          with:
+            repository: ${{ github.event.pull_request.head.repo.full_name }}
+            ref: ${{ github.event.pull_request.head.ref }}
             persist-credentials: false
 
         - name: Set up Python 3.12
@@ -49,13 +61,13 @@ jobs:
             folder: site  # Assuming mkdocs build output is the default 'site' directory
 
         - name: Preview Documentation (on PR)
-          if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
+          if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
           uses: rossjrw/pr-preview-action@v1
           with:
             source-dir: site  # Assuming mkdocs build output is the default 'site' directory
 
         - name: Preview Documentation from fork
-          if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]' }}
+          if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]' }}
           uses: JamesIves/github-pages-deploy-action@v4
           with:
             token: ${{ secrets.PUBLIC_PR_PREVIEW }}

--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -67,7 +67,7 @@ jobs:
             source-dir: site  # Assuming mkdocs build output is the default 'site' directory
 
         - name: Preview Documentation from fork
-          if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]' }}
+          if: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target') && github.event.pull_request.head.repo.full_name != github.repository && github.actor != 'dependabot[bot]' && secrets.PUBLIC_PR_PREVIEW != '' }}
           uses: JamesIves/github-pages-deploy-action@v4
           with:
             token: ${{ secrets.PUBLIC_PR_PREVIEW }}

--- a/docs/contribute/Code_Specifications/Details/Linear_Git_Repository.md
+++ b/docs/contribute/Code_Specifications/Details/Linear_Git_Repository.md
@@ -86,6 +86,7 @@ git push --force-with-lease
 | Commit staged changes | `git commit -m "Concise, present‑tense message"` |
 | Abort an in‑progress rebase | `git rebase --abort` |
 | Continue after fixing conflicts | `git rebase --continue` |
+| Force‑push after a rebase or squash | `git push --force-with-lease` |
 
 ---
 


### PR DESCRIPTION
build from fork test docs build

## Summary by Sourcery

Enable documentation builds and previews for forked pull requests by adding pull_request_target support, refining checkout logic, and introducing a dedicated preview deployment step; also update docs with the force-push command after rebases.

New Features:
- Deploy documentation previews for forked pull requests to a public repository for isolated testing

Enhancements:
- Enable pull_request_target trigger and conditional checkout logic in the mkdocs GitHub Actions workflow for secure fork handling
- Extend the Preview Documentation step to run on both pull_request and pull_request_target events

Documentation:
- Add force-push after rebase or squash command to the Linear Git Repository documentation guide