### PR TITLE
Move notebook buttons to TOC sidebar

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,19 +1,5 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="md-content__button-row">
-    {% if page.nb_url %}
-        <a href="https://colab.research.google.com/github/uncscode/particula/blob/main/docs/{{ page.file.src_path }}" title="Open in Google Colab" aria-label="Open this notebook in Google Colab" class="md-content__button md-icon" target="_blank" rel="noopener noreferrer">
-            {% include ".icons/material/open-in-new.svg" %}
-            Colab
-        </a>
-        <a href="{{ page.nb_url }}" title="Download Notebook" class="md-content__button md-icon" target="_blank" rel="noopener noreferrer">
-            {% include ".icons/material/download.svg" %}
-            Notebook
-        </a>
-    {% endif %}
-</div>
-
-{{ super() }}
-
+  {{ super() }}
 {% endblock content %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,5 +1,0 @@
-{% extends "base.html" %}
-
-{% block content %}
-  {{ super() }}
-{% endblock content %}

--- a/docs/overrides/partials/toc.html
+++ b/docs/overrides/partials/toc.html
@@ -1,3 +1,6 @@
+{#-
+  This file was automatically generated - do not edit
+-#}
 {% if page.nb_url %}
   <div class="md-content__button-row" style="margin-bottom: 1rem;">
       <a href="https://colab.research.google.com/github/uncscode/particula/blob/main/docs/{{ page.file.src_path }}"
@@ -17,5 +20,25 @@
       </a>
   </div>
 {% endif %}
-
-{{ super() }}
+{% set title = lang.t("toc") %}
+{% if config.mdx_configs.toc and config.mdx_configs.toc.title %}
+  {% set title = config.mdx_configs.toc.title %}
+{% endif %}
+<nav class="md-nav md-nav--secondary" aria-label="{{ title | e }}">
+  {% set toc = page.toc %}
+  {% set first = toc | first %}
+  {% if first and first.level == 1 %}
+    {% set toc = first.children %}
+  {% endif %}
+  {% if toc %}
+    <label class="md-nav__title" for="__toc">
+      <span class="md-nav__icon md-icon"></span>
+      {{ title }}
+    </label>
+    <ul class="md-nav__list" data-md-component="toc" data-md-scrollfix>
+      {% for toc_item in toc %}
+        {% include "partials/toc-item.html" %}
+      {% endfor %}
+    </ul>
+  {% endif %}
+</nav>

--- a/docs/overrides/partials/toc.html
+++ b/docs/overrides/partials/toc.html
@@ -1,0 +1,21 @@
+{% if page.nb_url %}
+  <div class="md-content__button-row" style="margin-bottom: 1rem;">
+      <a href="https://colab.research.google.com/github/uncscode/particula/blob/main/docs/{{ page.file.src_path }}"
+         title="Open in Google Colab"
+         aria-label="Open this notebook in Google Colab"
+         class="md-content__button md-icon"
+         target="_blank" rel="noopener noreferrer">
+          {% include ".icons/material/open-in-new.svg" %}
+          Colab
+      </a>
+      <a href="{{ page.nb_url }}"
+         title="Download Notebook"
+         class="md-content__button md-icon"
+         target="_blank" rel="noopener noreferrer">
+          {% include ".icons/material/download.svg" %}
+          Notebook
+      </a>
+  </div>
+{% endif %}
+
+{{ super() }}

--- a/docs/overrides/partials/toc.html
+++ b/docs/overrides/partials/toc.html
@@ -13,6 +13,7 @@
       </a>
       <a href="{{ page.nb_url }}"
          title="Download Notebook"
+         aria-label="Download this notebook"
          class="md-content__button md-icon"
          target="_blank" rel="noopener noreferrer">
           {% include ".icons/material/download.svg" %}


### PR DESCRIPTION
## Summary
- place "Open in Colab" and "Download Notebook" links in the sidebar toc
- clean up `main.html` override

## Testing
- `pytest -Werror`
- `mkdocs serve --strict` *(fails: Required dependencies of "social" plugin not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dba6e19608322bf44123e61e49d7a

## Summary by Sourcery

Move notebook action buttons into the TOC sidebar and clean up the redundant main.html override.

New Features:
- Display 'Open in Colab' and 'Download Notebook' buttons in the documentation TOC sidebar when a notebook URL is available.

Chores:
- Remove obsolete main.html override file.