### PR TITLE
Fix docs toc override path

### DIFF
--- a/docs/overrides/partials/toc.html
+++ b/docs/overrides/partials/toc.html
@@ -1,4 +1,4 @@
-{% extends "material/partials/toc.html" %}
+{% extends "partials/toc.html" %}
 
 {# Insert after the headline (before the list) #}
 {% block title %}


### PR DESCRIPTION
## Summary
- fix path for overriding the Table of Contents template so build can locate theme partial

## Testing
- `pytest -Werror`

------
https://chatgpt.com/codex/tasks/task_e_684dffa987c483228b6a53ad6dc74f35

## Summary by Sourcery

Bug Fixes:
- Correct the extends path in docs/overrides/partials/toc.html from "material/partials/toc.html" to "partials/toc.html"