### PR TITLE
Fix documentation links and toc template

### DIFF
--- a/docs/contribute/Feature_Workflow/Details/Add_Class.md
+++ b/docs/contribute/Feature_Workflow/Details/Add_Class.md
@@ -14,7 +14,7 @@ This is typically a wrapper around the functions you wrote in the previous step.
 - `__init__` with complete type hints.
 - Public interface first (getters, setters, actions).
 - Docstring that includes an “Examples” subsection.
-- Follow [Code Specifications](../Code_Specifications/index.md) for formatting.
+- Follow [Code Specifications](../../Code_Specifications/index.md) for formatting.
 
 ## Steps
 

--- a/docs/contribute/Feature_Workflow/Details/Add_Function.md
+++ b/docs/contribute/Feature_Workflow/Details/Add_Function.md
@@ -7,7 +7,7 @@ Create or update a module under particula/<area>/.
 ## Checklist
 
 * Python – no I/O or global state changes.
-* Follow [Code Specifications](../Code_Specifications/index.md) for formatting.
+* Follow [Code Specifications](../../Code_Specifications/index.md) for formatting.
 * Input validation via util.validate_inputs when applicable.
 * Logging: use `logger = logging.getLogger("particula")` and log at DEBUG.
 

--- a/docs/overrides/partials/toc.html
+++ b/docs/overrides/partials/toc.html
@@ -1,4 +1,4 @@
-{% extends "partials/toc.html" %}
+{% extends "material/partials/toc.html" %}
 
 {# Insert after the headline (before the list) #}
 {% block title %}


### PR DESCRIPTION
## Summary
- correct Code_Specifications links in Add_Class.md and Add_Function.md
- avoid recursive template include in toc override

## Testing
- `mkdocs build --strict` *(fails: ModuleNotFoundError: 'cairosvg')*
- `pytest -Werror`

------
https://chatgpt.com/codex/tasks/task_e_684e03628da48322b5aabed76b92472c