### PR TITLE
Fix ToC button placement

### DIFF
--- a/docs/overrides/partials/toc.html
+++ b/docs/overrides/partials/toc.html
@@ -1,23 +1,31 @@
-{#-
-  This file was automatically generated - do not edit
--#}
+{#-                       generated – do not edit                       -#}
 {% set title = lang.t("toc") %}
 {% if config.mdx_configs.toc and config.mdx_configs.toc.title %}
   {% set title = config.mdx_configs.toc.title %}
 {% endif %}
+
 <nav class="md-nav md-nav--secondary" aria-label="{{ title | e }}">
   {% set toc = page.toc %}
   {% set first = toc | first %}
   {% if first and first.level == 1 %}
     {% set toc = first.children %}
   {% endif %}
+
   {% if toc %}
     <label class="md-nav__title" for="__toc">
       <span class="md-nav__icon md-icon"></span>
       {{ title }}
     </label>
+
+    <ul class="md-nav__list" data-md-component="toc" data-md-scrollfix>
+      {% for toc_item in toc %}
+        {% include "partials/toc-item.html" %}
+      {% endfor %}
+    </ul>
+
+    {# ───────────────────── move buttons down here ───────────────────── #}
     {% if page.nb_url %}
-    <div class="md-content__button-row" style="margin-bottom: 1rem;">
+      <div class="md-content__button-row" style="margin-top: 1rem;">
         <a href="https://colab.research.google.com/github/uncscode/particula/blob/main/docs/{{ page.file.src_path }}"
            title="Open in Google Colab"
            aria-label="Open this notebook in Google Colab"
@@ -34,12 +42,7 @@
             {% include ".icons/material/download.svg" %}
             Notebook
         </a>
-    </div>
+      </div>
     {% endif %}
-    <ul class="md-nav__list" data-md-component="toc" data-md-scrollfix>
-      {% for toc_item in toc %}
-        {% include "partials/toc-item.html" %}
-      {% endfor %}
-    </ul>
   {% endif %}
 </nav>

--- a/docs/overrides/partials/toc.html
+++ b/docs/overrides/partials/toc.html
@@ -1,26 +1,6 @@
 {#-
   This file was automatically generated - do not edit
 -#}
-{% if page.nb_url %}
-  <div class="md-content__button-row" style="margin-bottom: 1rem;">
-      <a href="https://colab.research.google.com/github/uncscode/particula/blob/main/docs/{{ page.file.src_path }}"
-         title="Open in Google Colab"
-         aria-label="Open this notebook in Google Colab"
-         class="md-content__button md-icon"
-         target="_blank" rel="noopener noreferrer">
-          {% include ".icons/material/open-in-new.svg" %}
-          Colab
-      </a>
-      <a href="{{ page.nb_url }}"
-         title="Download Notebook"
-         aria-label="Download this notebook"
-         class="md-content__button md-icon"
-         target="_blank" rel="noopener noreferrer">
-          {% include ".icons/material/download.svg" %}
-          Notebook
-      </a>
-  </div>
-{% endif %}
 {% set title = lang.t("toc") %}
 {% if config.mdx_configs.toc and config.mdx_configs.toc.title %}
   {% set title = config.mdx_configs.toc.title %}
@@ -36,6 +16,26 @@
       <span class="md-nav__icon md-icon"></span>
       {{ title }}
     </label>
+    {% if page.nb_url %}
+    <div class="md-content__button-row" style="margin-bottom: 1rem;">
+        <a href="https://colab.research.google.com/github/uncscode/particula/blob/main/docs/{{ page.file.src_path }}"
+           title="Open in Google Colab"
+           aria-label="Open this notebook in Google Colab"
+           class="md-content__button md-icon"
+           target="_blank" rel="noopener noreferrer">
+            {% include ".icons/material/open-in-new.svg" %}
+            Colab
+        </a>
+        <a href="{{ page.nb_url }}"
+           title="Download Notebook"
+           aria-label="Download this notebook"
+           class="md-content__button md-icon"
+           target="_blank" rel="noopener noreferrer">
+            {% include ".icons/material/download.svg" %}
+            Notebook
+        </a>
+    </div>
+    {% endif %}
     <ul class="md-nav__list" data-md-component="toc" data-md-scrollfix>
       {% for toc_item in toc %}
         {% include "partials/toc-item.html" %}


### PR DESCRIPTION
## Summary
- move Colab/Notebook buttons to render under the Table of Contents header

## Testing
- `pytest -Werror`

------
https://chatgpt.com/codex/tasks/task_e_684ebb4cfe7883229b6f9436f2053e90

## Summary by Sourcery

Bug Fixes:
- Render Colab and Notebook buttons below the ToC list instead of above it and update spacing