### PR TITLE
Add liquid and hybrid vapor pressure strategies

### DIFF
--- a/particula/gas/__init__.py
+++ b/particula/gas/__init__.py
@@ -11,6 +11,8 @@ from particula.gas.vapor_pressure_strategies import (
     AntoineVaporPressureStrategy,
     ClausiusClapeyronStrategy,
     WaterBuckStrategy,
+    ArblasterLiquidVaporPressureStrategy,
+    LiquidClausiusHybridStrategy,
 )
 
 from particula.gas.vapor_pressure_builders import (


### PR DESCRIPTION
## Summary
- implement `ArblasterLiquidVaporPressureStrategy` for 5-term log polynomial
- add `LiquidClausiusHybridStrategy` to smoothly blend liquid and Clausius–Clapeyron approaches
- expose the new strategies in `particula.gas`
- test the new strategies
- document new strategies with expanded docstrings

## Testing
- `pytest -Werror`


------
https://chatgpt.com/codex/tasks/task_e_68518f39a1b48322a54601a0eeeff4ec