### PR TITLE
Handle optional thermo dependency and update tests

### DIFF
--- a/particula/util/materials/__init__.py
+++ b/particula/util/materials/__init__.py
@@ -1,4 +1,9 @@
 from .vapor_pressure import get_vapor_pressure
 from .surface_tension import get_surface_tension
+from .chemical_search import get_chemical_search
 
-__all__: list[str] = ["get_vapor_pressure", "get_surface_tension"]
+__all__: list[str] = [
+    "get_vapor_pressure",
+    "get_surface_tension",
+    "get_chemical_search",
+]

--- a/particula/util/materials/chemical_search.py
+++ b/particula/util/materials/chemical_search.py
@@ -1,0 +1,42 @@
+"""Utility functions for querying the thermo chemical database."""
+from __future__ import annotations
+
+from difflib import get_close_matches
+
+try:  # pragma: no cover - dependency optional
+    from thermo.chemical import Chemical
+    from thermo.identifiers import name_to_CAS
+except ImportError:  # pragma: no cover - dependency missing during import
+    Chemical = None
+    name_to_CAS = None
+
+
+def get_chemical_search(identifier: str) -> str | None:
+    """Return the resolved chemical name or a close match.
+
+    Parameters
+    ----------
+    identifier:
+        Any string accepted by ``thermo.chemical.Chemical`` (name, formula,
+        or CAS number).
+
+    Returns
+    -------
+    str | None
+        ``identifier`` if it directly resolves to a ``Chemical``. If not,
+        the closest matching chemical name from the thermo database, or
+        ``None`` if no close match is found.
+    """
+    if Chemical is None or name_to_CAS is None:
+        raise ImportError(
+            "The 'thermo' package is required for chemical search operations. "
+            "Please install it using 'pip install thermo'."
+        )
+
+    try:
+        Chemical(identifier)
+        return identifier
+    except Exception:
+        names = list(name_to_CAS.keys())
+        matches = get_close_matches(identifier, names, n=1, cutoff=0.6)
+        return matches[0] if matches else None

--- a/particula/util/materials/surface_tension.py
+++ b/particula/util/materials/surface_tension.py
@@ -6,13 +6,10 @@ from typing import Union
 import numpy as np
 from numpy.typing import NDArray
 
-try:
+try:  # pragma: no cover - optional dependency
     from thermo.chemical import Chemical
-except ImportError as e:
-    raise ImportError(
-        "The 'thermo' package is required for vapor pressure calculations. "
-        "Please install it using 'pip install thermo'."
-    ) from e
+except ImportError:  # pragma: no cover - dependency missing during import
+    Chemical = None
 
 
 def get_surface_tension(
@@ -60,6 +57,12 @@ def get_surface_tension(
         - D. R. Lide, *CRC Handbook of Chemistry and Physics*, 90th ed.,
           CRC Press, 2009.
     """
+    if Chemical is None:
+        raise ImportError(
+            "The 'thermo' package is required for vapor pressure calculations. "
+            "Please install it using 'pip install thermo'."
+        )
+
     temps = np.asarray(temperature, dtype=np.float64)
     chem = Chemical(chemical_identifier)
 

--- a/particula/util/materials/vapor_pressure.py
+++ b/particula/util/materials/vapor_pressure.py
@@ -6,13 +6,10 @@ from typing import Union
 import numpy as np
 from numpy.typing import NDArray
 
-try:
+try:  # pragma: no cover - optional dependency
     from thermo.chemical import Chemical
-except ImportError as e:
-    raise ImportError(
-        "The 'thermo' package is required for vapor pressure calculations. "
-        "Please install it using 'pip install thermo'."
-    ) from e
+except ImportError:  # pragma: no cover - dependency missing during import
+    Chemical = None
 
 
 def get_vapor_pressure(
@@ -59,6 +56,12 @@ def get_vapor_pressure(
         - R. H. Perry & D. W. Green, *Perry's Chemical Engineers' Handbook*,
           8th ed., McGraw-Hill, 2007.
     """
+    if Chemical is None:
+        raise ImportError(
+            "The 'thermo' package is required for vapor pressure calculations. "
+            "Please install it using 'pip install thermo'."
+        )
+
     temps = np.asarray(temperature, dtype=np.float64)
     chem = Chemical(chemical_identifier)
 

--- a/tests/materials/test_chemical_search.py
+++ b/tests/materials/test_chemical_search.py
@@ -1,0 +1,18 @@
+import pytest
+
+import particula.util.materials.chemical_search as chemical_search
+
+THERMO_AVAILABLE = chemical_search.Chemical is not None
+
+
+def test_get_chemical_search_exact():
+    if not THERMO_AVAILABLE:
+        pytest.skip("thermo is not installed")
+    assert chemical_search.get_chemical_search("water") is not None
+
+
+def test_get_chemical_search_fuzzy():
+    if not THERMO_AVAILABLE:
+        pytest.skip("thermo is not installed")
+    suggestion = chemical_search.get_chemical_search("watr")
+    assert suggestion is not None


### PR DESCRIPTION
## Summary
- make materials helpers importable without thermo installed
- skip chemical search tests if thermo isn't present

## Testing
- `pytest -Werror` *(fails: ImportError: The 'thermo' package is required)*

------
https://chatgpt.com/codex/tasks/task_e_6856177452b883229d5a2626940efeef

## Summary by Sourcery

Make the thermo dependency optional and extend vapor pressure and surface strategies with lookup table support; introduce new vapor pressure strategy classes and corresponding builder mixins, and update tests to cover the new functionality

New Features:
- Make thermo-based material utilities optional with import guards
- Introduce TableVaporPressureStrategy, ArblasterLiquidVaporPressureStrategy, and LiquidClausiusHybridStrategy for advanced vapor pressure models
- Add temperature-dependent surface tension support in SurfaceStrategy via lookup tables
- Provide BuilderSurfaceTensionTableMixin, BuilderTemperatureTableMixin, and TableVaporPressureBuilder for configurable tables

Bug Fixes:
- Skip chemical search tests when thermo package is not installed to prevent ImportError

Enhancements:
- Integrate table support into existing surface and vapor pressure builders
- Expand test suite to cover new strategies, mixins, and utility functions

Tests:
- Add tests for new vapor pressure strategies, surface tension and temperature table mixins, and utility functions