### PR TITLE
Mass transfer utils tests

### DIFF
--- a/particula/dynamics/condensation/mass_transfer_utils.py
+++ b/particula/dynamics/condensation/mass_transfer_utils.py
@@ -107,7 +107,9 @@ def apply_condensation_limit(
             gas_mass[need_scale] - evap_sum[need_scale]
         ) / cond_sum[need_scale]
     cond_scale = np.clip(cond_scale, 0.0, 1.0)
-    mass_to_change = np.where(pos_mask, mass_to_change * cond_scale, mass_to_change)
+    mass_to_change = np.where(
+        pos_mask, mass_to_change * cond_scale, mass_to_change
+    )
     return mass_to_change, evap_sum, neg_mask
 
 
@@ -147,7 +149,9 @@ def apply_evaporation_limit(
         ```
     """
     if particle_mass.ndim == 2:
-        inventory = (particle_mass * particle_concentration[:, None]).sum(axis=0)
+        inventory = (particle_mass * particle_concentration[:, None]).sum(
+            axis=0
+        )
     else:
         inventory = (particle_mass * particle_concentration).sum()
     evap_scale = np.ones_like(np.atleast_1d(evap_sum))
@@ -156,7 +160,9 @@ def apply_evaporation_limit(
         if need_scale:
             evap_scale = np.array([inventory / (-evap_sum)])
     else:
-        evap_scale[need_scale] = inventory[need_scale] / (-evap_sum[need_scale])
+        evap_scale[need_scale] = inventory[need_scale] / (
+            -evap_sum[need_scale]
+        )
     return np.where(neg_mask, mass_to_change * evap_scale, mass_to_change)
 
 

--- a/particula/dynamics/condensation/mass_transfer_utils.py
+++ b/particula/dynamics/condensation/mass_transfer_utils.py
@@ -1,6 +1,9 @@
 """Helper routines for condensation and evaporation calculations.
 
-These functions isolate common logic from :mod:`mass_transfer` so that each step can be tested independently. Each helper operates on arrays of mass change or particle properties and enforces specific physical limitations such as available gas mass or particle inventory.
+These functions isolate common logic from :mod:`mass_transfer` so that each
+step can be tested independently. Each helper operates on arrays of mass
+change or particle properties and enforces specific physical limitations
+such as available gas mass or particle inventory.
 """
 
 from numpy.typing import NDArray
@@ -140,4 +143,3 @@ def apply_per_bin_limit(
     else:
         limit = -particle_mass * particle_concentration
     return np.maximum(mass_to_change, limit)
-

--- a/particula/dynamics/condensation/mass_transfer_utils.py
+++ b/particula/dynamics/condensation/mass_transfer_utils.py
@@ -1,0 +1,143 @@
+"""Helper routines for condensation and evaporation calculations.
+
+These functions isolate common logic from :mod:`mass_transfer` so that each step can be tested independently. Each helper operates on arrays of mass change or particle properties and enforces specific physical limitations such as available gas mass or particle inventory.
+"""
+
+from numpy.typing import NDArray
+import numpy as np
+
+
+def calc_mass_to_change(
+    mass_rate: NDArray[np.float64],
+    time_step: float,
+    particle_concentration: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Return the mass change each particle would experience during `time_step`.
+
+    Parameters
+    ----------
+    mass_rate : NDArray[np.float64]
+        Mass transfer rate for each particle or `(particle, species)` pair
+        in units of `kg/s`.
+    time_step : float
+        Size of the time step `[s]`.
+    particle_concentration : NDArray[np.float64]
+        Number concentration of particles `[#/m^3]`.
+
+    Returns
+    -------
+    NDArray[np.float64]
+        Requested mass change for every particle/species combination.
+    """
+    if mass_rate.ndim == 2:
+        return mass_rate * time_step * particle_concentration[:, None]
+    return mass_rate * time_step * particle_concentration
+
+
+def apply_condensation_limit(
+    mass_to_change: NDArray[np.float64],
+    gas_mass: NDArray[np.float64],
+) -> tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.bool_]]:
+    """Scale condensation so that the column sum never exceeds the available gas mass.
+
+    Parameters
+    ----------
+    mass_to_change : NDArray[np.float64]
+        Requested mass change for each bin and species ``[kg]``.
+    gas_mass : NDArray[np.float64]
+        Total gas mass available for condensation ``[kg]``.
+
+    Returns
+    -------
+    tuple[NDArray[np.float64], NDArray[np.float64], NDArray[np.bool_]]
+        The scaled mass change, the evaporation sum for each species, and
+        a mask identifying evaporation elements.
+    """
+    pos_mask = mass_to_change > 0.0
+    neg_mask = mass_to_change < 0.0
+    cond_sum = np.where(pos_mask, mass_to_change, 0.0).sum(axis=0)
+    evap_sum = np.where(neg_mask, mass_to_change, 0.0).sum(axis=0)
+    cond_scale = np.ones_like(np.atleast_1d(cond_sum))
+    need_scale = (cond_sum > 0.0) & (cond_sum + evap_sum > gas_mass)
+    if np.ndim(cond_sum) == 0:
+        if need_scale:
+            cond_scale = np.array(
+                [(gas_mass.item() - evap_sum.item()) / cond_sum.item()]
+            )
+    else:
+        cond_scale[need_scale] = (
+            gas_mass[need_scale] - evap_sum[need_scale]
+        ) / cond_sum[need_scale]
+    cond_scale = np.clip(cond_scale, 0.0, 1.0)
+    mass_to_change = np.where(pos_mask, mass_to_change * cond_scale, mass_to_change)
+    return mass_to_change, evap_sum, neg_mask
+
+
+def apply_evaporation_limit(
+    mass_to_change: NDArray[np.float64],
+    particle_mass: NDArray[np.float64],
+    particle_concentration: NDArray[np.float64],
+    evap_sum: NDArray[np.float64],
+    neg_mask: NDArray[np.bool_],
+) -> NDArray[np.float64]:
+    """Scale evaporation so the column sum never exceeds the particle inventory."
+
+    Parameters
+    ----------
+    mass_to_change : NDArray[np.float64]
+        Candidate mass change for each bin and species ``[kg]``.
+    particle_mass : NDArray[np.float64]
+        Particle mass for each bin and species ``[kg]``.
+    particle_concentration : NDArray[np.float64]
+        Concentration of particles in each bin ``[#/m^3]``.
+    evap_sum : NDArray[np.float64]
+        Sum of evaporation (negative mass change) per species ``[kg]``.
+    neg_mask : NDArray[np.bool_]
+        Boolean mask indicating evaporation entries.
+
+    Returns
+    -------
+    NDArray[np.float64]
+        Mass change limited by the available particle mass.
+    """
+    if particle_mass.ndim == 2:
+        inventory = (particle_mass * particle_concentration[:, None]).sum(axis=0)
+    else:
+        inventory = (particle_mass * particle_concentration).sum()
+    evap_scale = np.ones_like(np.atleast_1d(evap_sum))
+    need_scale = -evap_sum > inventory
+    if np.ndim(evap_sum) == 0:
+        if need_scale:
+            evap_scale = np.array([inventory / (-evap_sum)])
+    else:
+        evap_scale[need_scale] = inventory[need_scale] / (-evap_sum[need_scale])
+    return np.where(neg_mask, mass_to_change * evap_scale, mass_to_change)
+
+
+def apply_per_bin_limit(
+    mass_to_change: NDArray[np.float64],
+    particle_mass: NDArray[np.float64],
+    particle_concentration: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Clip evaporation so no single bin loses more mass than it contains.
+
+    Parameters
+    ----------
+    mass_to_change : NDArray[np.float64]
+        Proposed mass change for each bin and species ``[kg]``.
+    particle_mass : NDArray[np.float64]
+        Mass of each particle bin and species ``[kg]``.
+    particle_concentration : NDArray[np.float64]
+        Number concentration of particles ``[#/m^3]``.
+
+    Returns
+    -------
+    NDArray[np.float64]
+        Mass change after enforcing the per-bin evaporation limit.
+    """
+    if mass_to_change.ndim == 2:
+        limit = -particle_mass * particle_concentration[:, None]
+    else:
+        limit = -particle_mass * particle_concentration
+    return np.maximum(mass_to_change, limit)
+

--- a/particula/dynamics/condensation/tests/mass_transfer_utils_test.py
+++ b/particula/dynamics/condensation/tests/mass_transfer_utils_test.py
@@ -1,4 +1,4 @@
-"""Test for chemical_properties.py module."""
+"""Test for mass_transfer_utilsmodule."""
 
 import numpy as np
 from particula.dynamics.condensation.mass_transfer_utils import (

--- a/particula/dynamics/condensation/tests/mass_transfer_utils_test.py
+++ b/particula/dynamics/condensation/tests/mass_transfer_utils_test.py
@@ -1,3 +1,5 @@
+"""Test for chemical_properties.py module."""
+
 import numpy as np
 from particula.dynamics.condensation.mass_transfer_utils import (
     calc_mass_to_change,
@@ -8,6 +10,7 @@ from particula.dynamics.condensation.mass_transfer_utils import (
 
 
 def test_calc_mass_to_change_single():
+    """Test mass change calculation for a single particle."""
     mass_rate = np.array([0.1, 0.2])
     time_step = 10.0
     conc = np.array([5.0, 4.0])
@@ -17,6 +20,7 @@ def test_calc_mass_to_change_single():
 
 
 def test_calc_mass_to_change_multi():
+    """Test mass change calculation for multiple particles."""
     mass_rate = np.array([[0.1, 0.05, 0.02], [0.2, 0.15, 0.1]])
     time_step = 10.0
     conc = np.array([5.0, 4.0])
@@ -26,6 +30,7 @@ def test_calc_mass_to_change_multi():
 
 
 def test_apply_condensation_limit_single():
+    """Test condensation limit application for a single particle."""
     mass = np.array([2.0, -1.0])
     gas_mass = np.array([0.5])
     limited, evap_sum, neg_mask = apply_condensation_limit(mass, gas_mass)
@@ -37,6 +42,7 @@ def test_apply_condensation_limit_single():
 
 
 def test_apply_condensation_limit_multi():
+    """Test condensation limit application for multiple particles."""
     mass = np.array([[1.0, 0.2], [1.0, -0.1]])
     gas_mass = np.array([1.0, 0.4])
     limited, evap_sum, neg_mask = apply_condensation_limit(mass.copy(), gas_mass)
@@ -52,6 +58,7 @@ def test_apply_condensation_limit_multi():
 
 
 def test_apply_evaporation_limit_single():
+    """Test evaporation limit application for a single particle."""
     mass = np.array([-2.0, -1.0])
     particle_mass = np.array([0.5, 1.0])
     conc = np.array([1.0, 2.0])
@@ -65,6 +72,7 @@ def test_apply_evaporation_limit_single():
 
 
 def test_apply_evaporation_limit_multi():
+    """Test evaporation limit application for multiple particles."""
     mass = np.array([[-4.0, -1.0], [-1.0, -2.0]])
     particle_mass = np.array([[1.0, 0.5], [1.0, 0.5]])
     conc = np.array([1.0, 2.0])
@@ -78,6 +86,7 @@ def test_apply_evaporation_limit_multi():
 
 
 def test_apply_per_bin_limit_single():
+    """Test per-bin limit application for a single particle."""
     mass = np.array([-2.0, -0.5])
     particle_mass = np.array([0.3, 0.4])
     conc = np.array([1.0, 2.0])
@@ -88,6 +97,7 @@ def test_apply_per_bin_limit_single():
 
 
 def test_apply_per_bin_limit_multi():
+    """Test per-bin limit application for multiple particles."""
     mass = np.array([[-2.0, -0.2], [0.1, -0.5]])
     particle_mass = np.array([[0.3, 0.4], [0.2, 0.1]])
     conc = np.array([2.0, 1.0])

--- a/particula/dynamics/condensation/tests/mass_transfer_utils_test.py
+++ b/particula/dynamics/condensation/tests/mass_transfer_utils_test.py
@@ -1,0 +1,97 @@
+import numpy as np
+from particula.dynamics.condensation.mass_transfer_utils import (
+    calc_mass_to_change,
+    apply_condensation_limit,
+    apply_evaporation_limit,
+    apply_per_bin_limit,
+)
+
+
+def test_calc_mass_to_change_single():
+    mass_rate = np.array([0.1, 0.2])
+    time_step = 10.0
+    conc = np.array([5.0, 4.0])
+    expected = mass_rate * time_step * conc
+    result = calc_mass_to_change(mass_rate, time_step, conc)
+    np.testing.assert_allclose(result, expected)
+
+
+def test_calc_mass_to_change_multi():
+    mass_rate = np.array([[0.1, 0.05, 0.02], [0.2, 0.15, 0.1]])
+    time_step = 10.0
+    conc = np.array([5.0, 4.0])
+    expected = mass_rate * time_step * conc[:, None]
+    result = calc_mass_to_change(mass_rate, time_step, conc)
+    np.testing.assert_allclose(result, expected)
+
+
+def test_apply_condensation_limit_single():
+    mass = np.array([2.0, -1.0])
+    gas_mass = np.array([0.5])
+    limited, evap_sum, neg_mask = apply_condensation_limit(mass, gas_mass)
+    scale = (gas_mass[0] - mass[mass < 0.0].sum()) / mass[mass > 0.0].sum()
+    expected = np.where(mass > 0.0, mass * scale, mass)
+    np.testing.assert_allclose(limited, expected)
+    np.testing.assert_allclose(evap_sum, -1.0)
+    np.testing.assert_array_equal(neg_mask, mass < 0.0)
+
+
+def test_apply_condensation_limit_multi():
+    mass = np.array([[1.0, 0.2], [1.0, -0.1]])
+    gas_mass = np.array([1.0, 0.4])
+    limited, evap_sum, neg_mask = apply_condensation_limit(mass.copy(), gas_mass)
+    pos_sum = np.where(mass > 0.0, mass, 0.0).sum(axis=0)
+    evap = np.where(mass < 0.0, mass, 0.0).sum(axis=0)
+    scale = np.ones_like(gas_mass)
+    mask = (pos_sum > 0.0) & (pos_sum + evap > gas_mass)
+    scale[mask] = (gas_mass[mask] - evap[mask]) / pos_sum[mask]
+    expected = np.where(mass > 0.0, mass * scale, mass)
+    np.testing.assert_allclose(limited, expected)
+    np.testing.assert_allclose(evap_sum, evap)
+    np.testing.assert_array_equal(neg_mask, mass < 0.0)
+
+
+def test_apply_evaporation_limit_single():
+    mass = np.array([-2.0, -1.0])
+    particle_mass = np.array([0.5, 1.0])
+    conc = np.array([1.0, 2.0])
+    evap_sum = mass.sum()
+    neg_mask = mass < 0.0
+    limited = apply_evaporation_limit(mass, particle_mass, conc, evap_sum, neg_mask)
+    inventory = (particle_mass * conc).sum()
+    scale = inventory / (-evap_sum)
+    expected = mass * scale
+    np.testing.assert_allclose(limited, expected)
+
+
+def test_apply_evaporation_limit_multi():
+    mass = np.array([[-4.0, -1.0], [-1.0, -2.0]])
+    particle_mass = np.array([[1.0, 0.5], [1.0, 0.5]])
+    conc = np.array([1.0, 2.0])
+    evap_sum = mass.sum(axis=0)
+    neg_mask = mass < 0.0
+    limited = apply_evaporation_limit(mass, particle_mass, conc, evap_sum, neg_mask)
+    inventory = (particle_mass * conc[:, None]).sum(axis=0)
+    scale = inventory / (-evap_sum)
+    expected = mass * scale
+    np.testing.assert_allclose(limited, expected)
+
+
+def test_apply_per_bin_limit_single():
+    mass = np.array([-2.0, -0.5])
+    particle_mass = np.array([0.3, 0.4])
+    conc = np.array([1.0, 2.0])
+    limit = -particle_mass * conc
+    expected = np.maximum(mass, limit)
+    result = apply_per_bin_limit(mass, particle_mass, conc)
+    np.testing.assert_allclose(result, expected)
+
+
+def test_apply_per_bin_limit_multi():
+    mass = np.array([[-2.0, -0.2], [0.1, -0.5]])
+    particle_mass = np.array([[0.3, 0.4], [0.2, 0.1]])
+    conc = np.array([2.0, 1.0])
+    limit = -particle_mass * conc[:, None]
+    expected = np.maximum(mass, limit)
+    result = apply_per_bin_limit(mass, particle_mass, conc)
+    np.testing.assert_allclose(result, expected)


### PR DESCRIPTION
## Summary
- add dedicated tests for `mass_transfer_utils` helper functions

## Testing
- `pytest -Werror`


------
https://chatgpt.com/codex/tasks/task_e_6859491c1ae8832284bf5fd7039e7c62

## Summary by Sourcery

Introduce independent helper functions for mass-change computation and physical limits, update core mass transfer methods to delegate to these helpers, and add comprehensive unit tests for each utility.

New Features:
- Extract utility functions for mass transfer calculations into a new module

Enhancements:
- Refactor single- and multi-species mass transfer routines to use the new helpers

Tests:
- Add dedicated unit tests for each mass_transfer_utils function covering single and multi-dimensional cases