### PR TITLE
Fix ruff

### DIFF
--- a/docs/.assets/mk_generator.py
+++ b/docs/.assets/mk_generator.py
@@ -1,5 +1,4 @@
-"""Handsdown to generate documentation for the project.
-"""
+"""Generate documentation using Handsdown."""
 
 import os
 from pathlib import Path

--- a/docs/.assets/vector_file_generator.py
+++ b/docs/.assets/vector_file_generator.py
@@ -1,7 +1,5 @@
 # %%
-"""For vector store upload, we need to convert all notebooks and python files in
-a directory to Markdown files.
-"""
+"""Convert notebooks and Python files in a directory to Markdown."""
 import os
 import shutil
 from pathlib import Path
@@ -14,9 +12,7 @@ from nbconvert import MarkdownExporter
 
 
 def convert_notebooks_to_markdown(notebook_paths, output_dir):
-    """Convert a list of notebooks (.ipynb) and markdown files (.md) to Markdown
-    files, writing the results into the specified output directory.
-    """
+    """Convert notebooks and Markdown files to Markdown."""
     exporter = MarkdownExporter()
     exporter.template_name = "classic"
 

--- a/docs/.assets/vector_store_upload.py
+++ b/docs/.assets/vector_store_upload.py
@@ -1,6 +1,5 @@
 # %%
-"""This script uploads the API, Examples, and Docs to the vector store.
-"""
+"""Upload API, examples, and docs to the vector store."""
 
 import os
 from pathlib import Path
@@ -193,8 +192,7 @@ def get_current_commit():
 
 
 def get_changed_files(previous_commit_hash):
-    """Get a list of files changed between the previous commit and the current
-    commit.
+    """Get files changed between the previous commit and the current commit.
 
     Arguments:
         - previous_commit_hash : The hash of the previous commit.
@@ -460,7 +458,7 @@ def refresh_changed_files(client, vector_store_id):
         print("No files to update.")
         return
     # Iterate over the files to update
-    for file_path, file_info in file_to_update.items():
+    for _file_path, file_info in file_to_update.items():
         if file_info["method"] == "update":
             update_vector_store_file(
                 client=client,
@@ -477,7 +475,7 @@ def refresh_all_files(
     client,
     vector_store_id=VECTOR_STORE_ID,
 ):
-    """Delete all files from the vector store and re-upload everything from temp.
+    """Delete all files from the vector store and re-upload from temp.
 
     Arguments:
         - client : The OpenAI client instance.

--- a/particula/abc_builder.py
+++ b/particula/abc_builder.py
@@ -13,8 +13,7 @@ logger = logging.getLogger("particula")
 
 
 class BuilderABC(ABC):
-    """Abstract base class for builders with common methods to check keys and
-    set parameters from a dictionary.
+    """Abstract base class for builders to check keys and set parameters.
 
     Attributes:
         - required_parameters: List of required parameters for the builder.
@@ -48,6 +47,7 @@ class BuilderABC(ABC):
     """
 
     def __init__(self, required_parameters: Optional[list[str]] = None):
+        """Initialize builder with required parameters."""
         self.required_parameters = required_parameters or []
 
     def check_keys(self, parameters: dict[str, Any]):

--- a/particula/abc_factory.py
+++ b/particula/abc_factory.py
@@ -1,6 +1,4 @@
-"""Abstract Base Class for Factory classes, that use builders to create
-strategy objects.
-"""
+"""Abstract base class for factories that use builders to create strategies."""
 
 import logging
 from abc import ABC, abstractmethod
@@ -71,8 +69,7 @@ class StrategyFactoryABC(ABC, Generic[BuilderT, StrategyT]):
     def get_strategy(
         self, strategy_type: str, parameters: Optional[Dict[str, Any]] = None
     ) -> StrategyT:
-        """Create a strategy instance for the specified type using its
-        corresponding builder.
+        """Create a strategy instance using its corresponding builder.
 
         Arguments:
             - strategy_type (str): Name of the strategy to build.

--- a/particula/builder_mixin.py
+++ b/particula/builder_mixin.py
@@ -36,6 +36,7 @@ class BuilderDensityMixin:
     """
 
     def __init__(self):
+        """Initialize density mixin."""
         self.density = None
 
     @validate_inputs({"density": "positive"})
@@ -85,6 +86,7 @@ class BuilderSurfaceTensionMixin:
     """
 
     def __init__(self):
+        """Initialize surface tension mixin."""
         self.surface_tension = None
 
     @validate_inputs({"surface_tension": "positive"})
@@ -138,6 +140,7 @@ class BuilderSurfaceTensionTableMixin:
     """
 
     def __init__(self):
+        """Initialize surface tension table mixin."""
         self.surface_tension_table = None
 
     @validate_inputs({"surface_tension_table": "positive"})
@@ -173,6 +176,7 @@ class BuilderMolarMassMixin:
     """
 
     def __init__(self):
+        """Initialize molar mass mixin."""
         self.molar_mass = None
 
     @validate_inputs({"molar_mass": "positive"})
@@ -228,6 +232,7 @@ class BuilderConcentrationMixin:
     """
 
     def __init__(self, default_units: str = "kg/m^3"):
+        """Initialize concentration mixin."""
         self.concentration = None
         self.default_units = default_units if default_units else "kg/m^3"
 
@@ -278,6 +283,7 @@ class BuilderChargeMixin:
     """
 
     def __init__(self):
+        """Initialize charge mixin."""
         self.charge = None
 
     def set_charge(
@@ -318,6 +324,7 @@ class BuilderPhaseIndexMixin:
     """
 
     def __init__(self):
+        """Initialize phase index mixin."""
         self.phase_index = None
 
     def set_phase_index(
@@ -346,6 +353,7 @@ class BuilderMassMixin:
     """
 
     def __init__(self):
+        """Initialize mass mixin."""
         self.mass = None
 
     @validate_inputs({"mass": "nonnegative"})
@@ -390,6 +398,7 @@ class BuilderVolumeMixin:
     """
 
     def __init__(self):
+        """Initialize volume mixin."""
         self.volume = None
 
     @validate_inputs({"volume": "nonnegative"})
@@ -434,6 +443,7 @@ class BuilderRadiusMixin:
     """
 
     def __init__(self):
+        """Initialize radius mixin."""
         self.radius = None
 
     @validate_inputs({"radius": "nonnegative"})
@@ -479,6 +489,7 @@ class BuilderTemperatureMixin:
     """
 
     def __init__(self):
+        """Initialize temperature mixin."""
         self.temperature = None
 
     @validate_inputs({"temperature": "finite"})
@@ -534,6 +545,7 @@ class BuilderTemperatureTableMixin:
     """
 
     def __init__(self):
+        """Initialize temperature table mixin."""
         self.temperature_table = None
 
     @validate_inputs({"temperature_table": "finite"})
@@ -571,6 +583,7 @@ class BuilderPressureMixin:
     """
 
     def __init__(self):
+        """Initialize pressure mixin."""
         self.pressure = None
 
     @validate_inputs({"pressure": "nonnegative"})
@@ -621,6 +634,7 @@ class BuilderLognormalMixin:
     """
 
     def __init__(self):
+        """Initialize lognormal distribution mixin."""
         self.mode = None
         self.number_concentration = None
         self.geometric_standard_deviation = None
@@ -724,6 +738,7 @@ class BuilderParticleResolvedCountMixin:
     """
 
     def __init__(self):
+        """Initialize particle-resolved count mixin."""
         self.particle_resolved_count = None
 
     @validate_inputs({"particle_resolved_count": "positive"})


### PR DESCRIPTION
## Summary
- clean up docstrings for ruff lint
- update builder mixins with simple init docs
- tweak variable names in vector store helpers

## Testing
- `ruff check docs/.assets/mk_generator.py docs/.assets/vector_file_generator.py docs/.assets/vector_store_upload.py particula/abc_builder.py particula/abc_factory.py particula/builder_mixin.py`
- `pytest -Werror`

------
https://chatgpt.com/codex/tasks/task_e_6860065747448322a9d78530bf04499f

## Summary by Sourcery

Update docstrings across the codebase to satisfy ruff lint rules by adding missing init docstrings, simplifying existing docstrings, and adjusting variable naming in a documentation script.

Enhancements:
- Add simple __init__ docstrings to all builder mixin classes
- Simplify and standardize multi-line docstrings in docs asset scripts and core builder classes
- Rename unused loop variable to _file_path in vector_store_upload for lint compliance