### PR TITLE
Kelvin term limits

### DIFF
--- a/particula/particles/properties/tests/kelvin_effect_test.py
+++ b/particula/particles/properties/tests/kelvin_effect_test.py
@@ -79,3 +79,63 @@ def test_prop_kelvin_term_broadcast_single():
     np.testing.assert_allclose(
         get_kelvin_term(radius, kelvin_radius_value), expected_term, rtol=1e-8
     )
+
+
+def test_kelvin_radius_high_temperature_limit():
+    """Kelvin radius should shrink at high temperature."""
+    surface_tension = 0.072
+    density = 1000
+    molar_mass = 0.018
+    temperature = 10000.0
+    expected = (2 * surface_tension * molar_mass) / (
+        8.314 * temperature * density
+    )
+    result = get_kelvin_radius(
+        surface_tension, density, molar_mass, temperature
+    )
+    assert np.isclose(result, expected)
+    assert result < 1e-10
+
+    radii = np.array([1e-9, 1e-12])
+    expected_term = np.exp(result / radii)
+    np.testing.assert_allclose(get_kelvin_term(radii, result), expected_term)
+
+
+def test_kelvin_radius_low_surface_tension():
+    """Kelvin radius should shrink with small surface tension."""
+    surface_tension = 1e-10
+    density = 1000
+    molar_mass = 0.018
+    temperature = 298.0
+    expected = (2 * surface_tension * molar_mass) / (
+        8.314 * temperature * density
+    )
+    result = get_kelvin_radius(
+        surface_tension, density, molar_mass, temperature
+    )
+    assert np.isclose(result, expected)
+    assert result > 0
+
+    radii = np.array([1e-9, 1e-12])
+    expected_term = np.exp(result / radii)
+    np.testing.assert_allclose(get_kelvin_term(radii, result), expected_term)
+
+
+def test_kelvin_radius_combined_limits():
+    """Kelvin radius at high T and low surface tension remains finite."""
+    surface_tension = 1e-10
+    density = 1000
+    molar_mass = 0.018
+    temperature = 10000.0
+    expected = (2 * surface_tension * molar_mass) / (
+        8.314 * temperature * density
+    )
+    result = get_kelvin_radius(
+        surface_tension, density, molar_mass, temperature
+    )
+    assert np.isclose(result, expected)
+    assert 0 < result < 1e-10
+
+    radii = np.array([1e-9, 1e-12])
+    expected_term = np.exp(result / radii)
+    np.testing.assert_allclose(get_kelvin_term(radii, result), expected_term)


### PR DESCRIPTION
## Summary
- extend Kelvin radius extreme tests to check Kelvin term stability at tiny particle radii

## Testing
- `ruff format particula/particles/properties/tests/kelvin_effect_test.py --silent`
- `ruff check particula/particles/properties/tests/kelvin_effect_test.py --quiet`
- `pytest -Werror -q`

------
https://chatgpt.com/codex/tasks/task_e_68651e4b7af48322927e973abfe8d146