### PR TITLE
docs(readme): add bash hint to conda install snippet

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,6 @@ pip install particula
 
 Or install via conda:
 
-```
+``` bash
 conda install -c conda-forge particula
 ```


### PR DESCRIPTION
## Summary

Add a bash language hint to the conda installation snippet in `readme.md` so it matches the existing pip installation example and renders with proper syntax highlighting.

## Changes

- Update the conda installation fenced code block in `readme.md` to use a `bash` language hint.

## Testing

- Documentation-only change; no runtime code modified.
- Tests and linters were run via the ADW patch workflow and are passing.

## Scientific Context

- Not applicable (documentation-only change).

## Checklist

- [x] Tests pass locally (via ADW workflow)
- [x] Linting passes (ruff check + format)
- [x] Documentation updated
- [ ] Type hints added
- [ ] Examples updated (not required)

Closes #827

---
**ADW Workflow ID**: `3e899a2a`