### PR TITLE
fix(tests): register pytest markers via conftest.py for conda-build

### DIFF
--- a/particula/conftest.py
+++ b/particula/conftest.py
@@ -1,0 +1,21 @@
+"""Pytest configuration for particula test suite.
+
+This file registers custom markers and configures pytest options.
+Having markers here ensures they are registered even in environments
+where pyproject.toml configuration may not be read (e.g., conda-build).
+"""
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register custom markers for the test suite."""
+    config.addinivalue_line(
+        "markers",
+        "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+    )
+    config.addinivalue_line(
+        "markers",
+        "performance: marks tests as performance-intensive "
+        "(deselect with '-m \"not performance\"')",
+    )


### PR DESCRIPTION
## Summary

Adds `conftest.py` to programmatically register custom pytest markers (`slow`, `performance`), fixing conda-build test collection failures.

## Problem

During conda-build, pytest was failing with `PytestUnknownMarkWarning` for the custom markers `slow` and `performance`. In conda-build environments, this warning is treated as an error, causing the build to fail.

## Cause

The markers are defined in `pyproject.toml`, but conda-build test environments may not read pytest configuration from `pyproject.toml`. This results in pytest not recognizing the custom markers when collecting tests.

## Solution

Added `particula/conftest.py` that registers the markers programmatically via `pytest_configure()`. This ensures markers are recognized regardless of how pytest is invoked or which configuration files are available in the environment.

## Testing

- Verified pytest collection works without warnings
- Confirmed markers are properly registered with `pytest --markers`
- Markers continue to work as expected (e.g., `-m "not slow"`)