### PR TITLE
fix: #886 - [E2-F2-P3] Create EquilibriaFactory

### DIFF
--- a/particula/equilibria/__init__.py
+++ b/particula/equilibria/__init__.py
@@ -3,13 +3,13 @@
 from particula.equilibria.equilibria_builders import (
     LiquidVaporPartitioningBuilder,
 )
+from particula.equilibria.equilibria_factories import EquilibriaFactory
 from particula.equilibria.equilibria_strategies import (
     EquilibriaStrategy,
     EquilibriumResult,
     LiquidVaporPartitioningStrategy,
     PhaseConcentrations,
 )
-from particula.equilibria.equilibria_factories import EquilibriaFactory
 from particula.equilibria.partitioning import (
     get_properties_for_liquid_vapor_partitioning,
     liquid_vapor_obj_function,

--- a/particula/equilibria/equilibria_factories.py
+++ b/particula/equilibria/equilibria_factories.py
@@ -27,7 +27,6 @@ from particula.equilibria.equilibria_builders import (
 )
 from particula.equilibria.equilibria_strategies import EquilibriaStrategy
 
-
 BuilderType = LiquidVaporPartitioningBuilder
 
 

--- a/particula/equilibria/tests/equilibria_factories_test.py
+++ b/particula/equilibria/tests/equilibria_factories_test.py
@@ -1,7 +1,10 @@
+"""Tests for :class:`EquilibriaFactory` behavior."""
+
 from __future__ import annotations
 
-import pytest
+from typing import Any, Dict, cast
 
+import pytest
 from particula.equilibria.equilibria_builders import (
     LiquidVaporPartitioningBuilder,
 )
@@ -15,13 +18,20 @@ from particula.equilibria.equilibria_strategies import (
 @pytest.fixture()
 def factory() -> EquilibriaFactory:
     """Provide a fresh factory per test."""
-
     return EquilibriaFactory()
+
+
+def _liquid_vapor_strategy(
+    strategy: EquilibriaStrategy,
+) -> LiquidVaporPartitioningStrategy:
+    """Assert strategy is liquid_vapor and return the typed instance."""
+    assert isinstance(strategy, LiquidVaporPartitioningStrategy)
+
+    return cast(LiquidVaporPartitioningStrategy, strategy)
 
 
 def test_get_builders_contains_liquid_vapor(factory: EquilibriaFactory) -> None:
     """Factory exposes liquid_vapor builder."""
-
     builders = factory.get_builders()
 
     assert "liquid_vapor" in builders
@@ -32,7 +42,6 @@ def test_get_builders_returns_fresh_instances(
     factory: EquilibriaFactory,
 ) -> None:
     """Each call returns new builder instances."""
-
     first = factory.get_builders()
     second = factory.get_builders()
 
@@ -42,7 +51,6 @@ def test_get_builders_returns_fresh_instances(
 
 def test_factory_instances_have_isolated_builders() -> None:
     """Factories do not share builder instances."""
-
     first_factory = EquilibriaFactory()
     second_factory = EquilibriaFactory()
 
@@ -56,10 +64,8 @@ def test_get_strategy_liquid_vapor_returns_strategy(
     factory: EquilibriaFactory,
 ) -> None:
     """Default strategy is produced with default water_activity."""
+    strategy = _liquid_vapor_strategy(factory.get_strategy("liquid_vapor"))
 
-    strategy = factory.get_strategy("liquid_vapor")
-
-    assert isinstance(strategy, LiquidVaporPartitioningStrategy)
     assert strategy.water_activity == pytest.approx(0.5)
 
 
@@ -67,32 +73,24 @@ def test_get_strategy_with_parameters_passes_water_activity(
     factory: EquilibriaFactory,
 ) -> None:
     """Parameters flow into builder and strategy."""
-
-    strategy = factory.get_strategy(
-        "liquid_vapor", parameters={"water_activity": 0.8}
+    strategy = _liquid_vapor_strategy(
+        factory.get_strategy("liquid_vapor", parameters={"water_activity": 0.8})
     )
 
-    assert isinstance(strategy, LiquidVaporPartitioningStrategy)
     assert strategy.water_activity == pytest.approx(0.8)
 
 
 def test_get_strategy_case_insensitive(factory: EquilibriaFactory) -> None:
     """Strategy lookup ignores case and underscores variance."""
+    lower = _liquid_vapor_strategy(factory.get_strategy("liquid_vapor"))
+    upper = _liquid_vapor_strategy(factory.get_strategy("LIQUID_VAPOR"))
+    mixed = _liquid_vapor_strategy(factory.get_strategy("Liquid_Vapor"))
 
-    lower = factory.get_strategy("liquid_vapor")
-    upper = factory.get_strategy("LIQUID_VAPOR")
-    mixed = factory.get_strategy("Liquid_Vapor")
-
-    assert all(
-        isinstance(strategy, LiquidVaporPartitioningStrategy)
-        for strategy in (lower, upper, mixed)
-    )
     assert lower.water_activity == upper.water_activity == mixed.water_activity
 
 
 def test_get_strategy_unknown_type_raises(factory: EquilibriaFactory) -> None:
     """Unknown strategy names raise ValueError with hint."""
-
     with pytest.raises(ValueError, match="Unknown strategy type"):
         factory.get_strategy("missing")
 
@@ -101,31 +99,32 @@ def test_get_strategy_invalid_parameters_raises(
     factory: EquilibriaFactory,
 ) -> None:
     """Invalid parameter values propagate as ValueError."""
-
     with pytest.raises(ValueError, match="water_activity must be in"):
         factory.get_strategy("liquid_vapor", parameters={"water_activity": 1.5})
 
 
 def test_empty_parameters_defaults_applied(factory: EquilibriaFactory) -> None:
     """Empty parameter dict uses builder defaults."""
+    strategy = _liquid_vapor_strategy(
+        factory.get_strategy("liquid_vapor", parameters={})
+    )
 
-    strategy = factory.get_strategy("liquid_vapor", parameters={})
-
-    assert isinstance(strategy, EquilibriaStrategy)
     assert strategy.water_activity == pytest.approx(0.5)
 
 
 def test_none_parameters_defaults_applied(factory: EquilibriaFactory) -> None:
     """None parameters use defaults without error."""
+    strategy = _liquid_vapor_strategy(
+        factory.get_strategy("liquid_vapor", parameters=None)
+    )
 
-    strategy = factory.get_strategy("liquid_vapor", parameters=None)
-
-    assert isinstance(strategy, EquilibriaStrategy)
     assert strategy.water_activity == pytest.approx(0.5)
 
 
 def test_non_dict_parameters_raises(factory: EquilibriaFactory) -> None:
     """Non-mapping parameter inputs raise type or value errors."""
-
     with pytest.raises((TypeError, ValueError)):
-        factory.get_strategy("liquid_vapor", parameters="bad")
+        factory.get_strategy(
+            "liquid_vapor",
+            parameters=cast(Dict[str, Any], "bad"),
+        )


### PR DESCRIPTION
**Target Branch:** `main`

**Fixes #886** | Workflow: `1d906f5f`

## Summary

Adds the `EquilibriaFactory` so callers can obtain equilibria strategies by name, mirroring the factory pattern used elsewhere in particula. The factory manages a case-insensitive registry of builders, forwards parameter maps after making a local copy, and raises a helpful `ValueError` when an unknown strategy name is requested. Co-located tests cover builder registration, parameter propagation, case-insensitive lookup, and the expected error handling.

## What Changed

### New Components

- `particula/equilibria/equilibria_factories.py` - Introduces `EquilibriaFactory`, implements `get_builders()` returning fresh builders, and `get_strategy()` that normalizes strategy names, copies parameter maps, delegates validation to builders, and reports valid choices when an unknown name is supplied.
- `particula/equilibria/tests/equilibria_factories_test.py` - Adds tests covering builder map contents, fresh builder instances, parameter forwarding, case-insensitive lookup, handling of empty/`None` parameters, and expected exceptions for invalid names or parameter values.

### Modified Components

- `particula/equilibria/__init__.py` - Re-exports `EquilibriaFactory` so the new entry point is available from the equilibria package.

### Tests Added/Updated

- `particula/equilibria/tests/equilibria_factories_test.py` - Validates strategy creation defaults, parameterized builds, case-insensitive lookups, and error paths to achieve full coverage of the factory logic.

## How It Works

Every call to `get_builders()` returns a fresh mapping keyed by lowercased names so factories cannot share builder instances inadvertently. `get_strategy()` lowercases the requested name, looks it up in the builder map, copies the provided parameter dict (if any) before passing it to the builder, and finally builds the strategy. A `ValueError` lists available strategy names when a caller requests something unknown, keeping the factory behavior predictable and transparent.

## Implementation Notes

- **Why this approach**: Matching the existing factory infrastructure keeps equilibria code consistent with `WallLossFactory` and friends, making it easy to add future strategies.
- **Error messaging**: Unknown strategy names echo the valid options so callers can correct typos without inspecting code.
- **Builder isolation**: Fresh builder instances guard against shared mutable state between successive factory calls.

## Testing

- Not run (not requested)
