### PR TITLE
fix: #1022 - [E3-F1-P2] Add computed properties and copy() method to ParticleData

### DIFF
--- a/particula/particles/particle_data.py
+++ b/particula/particles/particle_data.py
@@ -170,18 +170,20 @@ class ParticleData:
 
     @property
     def effective_density(self) -> NDArray[np.float64]:
-        """Volume-weighted effective density per particle.
+        """Mass-weighted effective density per particle.
 
         Returns:
             Effective density in kg/m^3 with shape (n_boxes, n_particles).
         """
-        volumes_per_species = self.masses / self.density
-        total_volume = np.sum(volumes_per_species, axis=-1)
+        # Match ParticleRepresentation.get_effective_density():
+        # sum_i(m_i * rho_i) / sum_i(m_i)
+        mass_weighted_density_sum = np.sum(self.masses * self.density, axis=-1)
+        total_mass = self.total_mass
         return np.divide(
-            self.total_mass,
-            total_volume,
-            where=total_volume > 0,
-            out=np.zeros_like(total_volume),
+            mass_weighted_density_sum,
+            total_mass,
+            where=total_mass > 0,
+            out=np.zeros_like(total_mass),
         )
 
     @property


### PR DESCRIPTION
**Target Branch:** `main`

**Fixes #1022** | Workflow: `1127b8d2`

## Summary

Adds the requested derived accessors and deep-copy helper to `ParticleData` so callers can fetch dimensions, radii, total mass, effective density, and mass fractions without redundant storage while ensuring the values stay zero-safe. The new `copy()` method preserves immutability guarantees for callers needing snapshots, and the implementation mirrors the formulas already employed by `ParticleRepresentation` so the numbers line up with existing expectations.

## What Changed

### Modified Components

- `particula/particles/particle_data.py` - Introduced `n_boxes`, `n_particles`, and `n_species` properties plus `radii`, `total_mass`, `effective_density`, and `mass_fractions` accessors, all documented with returns sections and zero-division safety. Added a `copy()` method that deep copies every array so mutations no longer leak.
- `particula/particles/tests/particle_data_test.py` - Expanded the test suite with coverage for every new property (including zero-mass radii, effective density, and mass fractions cases) and the deep-copy behavior.

### Tests Added/Updated

- `particula/particles/tests/particle_data_test.py` – Validates dimensions, radii (single/multi-species/zero mass), total mass, effective density (single/multi-species/zero mass), mass fractions (normal/zero mass), and the `copy()` semantics (independence and value preservation).

## How It Works

`,radii` aggregates per-species volumes (`mass / density`), sums them over species, and then computes the sphere radius via `(3V / 4π)^(1/3)` so the value matches the existing representation logic. `effective_density` and `mass_fractions` reuse zero-safe `np.divide` calls with `where` + `out` to gracefully return zeros when the total volume or mass is zero. `copy()` simply wraps `np.copy` for every array field so the returned `ParticleData` can be mutated without affecting the original.

## Implementation Notes

- **Zero-safe math:** All divides guard against zero totals to avoid NaN/Inf and to keep shapes consistent even when particles have no mass.
- **Consistency with `ParticleRepresentation`:** The formulas mirror the existing utilities (`get_effective_density`, radius strategy) so downstream consumers get identical numbers.
- **Deep copy semantics:** `copy()` duplicates each NumPy array so callers can snapshot state before in-place updates.

## Testing

- **Unit tests:** `pytest particula/particles/tests/particle_data_test.py`
