### PR TITLE
Add custom js for mathjax, remove polyfill

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,5 @@
+window.MathJax = {
+  tex: {
+    inlineMath: {'[+]': [['$', '$']]}
+  }
+};

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,8 +97,7 @@ markdown_extensions:
 
 extra_javascript:
   - javascripts/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
-  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
+  - https://unpkg.com/mathjax@4.1.0/tex-mml-chtml.js
 
 plugins:
   - search


### PR DESCRIPTION
Resolves #1048 
Polyfill was sold and potentially no longer safe.
The website is also no longer live.

Mathjax is updated to v4.1.0.
Custom mathjax.js script added to allow for single dollar signs as math delimiters.