### PR TITLE
docs: revise E3 epic and feature plans with shipping status and expanded GPU strategy

### DIFF
--- a/adw-docs/dev-plans/features/E3-F1-particle-data-container.md
+++ b/adw-docs/dev-plans/features/E3-F1-particle-data-container.md
@@ -1,10 +1,10 @@
 # Feature E3-F1: Particle Data Container
 
 **Parent Epic**: [E3: Data Representation Refactor](../epics/E3-data-representation-refactor.md)
-**Status**: Planning
+**Status**: Shipped
 **Priority**: P1
 **Start Date**: TBD
-**Last Updated**: 2026-01-19
+**Last Updated**: 2026-02-14
 
 ## Summary
 
@@ -370,42 +370,43 @@ def to_representation(
 
 ## Phase Checklist
 
-- [ ] **E3-F1-P1**: Define `ParticleData` dataclass with batched fields
-  - Issue: TBD | Size: M | Status: Not Started
-  - Create `particula/particles/particle_data.py`
-  - Define dataclass with masses, concentration, charge, density, volume
+- [x] **E3-F1-P1**: Define `ParticleData` dataclass with batched fields
+  - Issue: TBD | Size: M | Status: Shipped
+  - Created `particula/particles/particle_data.py`
+  - Defined dataclass with masses, concentration, charge, density, volume
   - Shape convention: (n_boxes, n_particles, ...) for batch dimension
-  - Add `__post_init__` validation for shape consistency
-  - Add type hints using numpy.typing
-  - Write `particula/particles/tests/particle_data_test.py`
+  - `__post_init__` validation for shape consistency
+  - Type hints using numpy.typing
+  - Written `particula/particles/tests/particle_data_test.py`
   - Tests for instantiation, validation errors, shape checking
 
-- [ ] **E3-F1-P2**: Add computed properties
-  - Issue: TBD | Size: S | Status: Not Started
-  - Add n_boxes, n_particles, n_species properties
-  - Add radii property (computed from mass/density)
-  - Add total_mass, effective_density, mass_fractions properties
-  - Add copy() method for deep copying
-  - Extend test file with property tests
+- [x] **E3-F1-P2**: Add computed properties
+  - Issue: TBD | Size: S | Status: Shipped
+  - Added n_boxes, n_particles, n_species properties
+  - Added radii property (computed from mass/density)
+  - Added total_mass, effective_density, mass_fractions properties
+  - Added copy() method for deep copying
+  - Extended test file with property tests
   - Tests for computed values, edge cases (zero mass, etc.)
 
-- [ ] **E3-F1-P3**: Create `ParticleDataBuilder` with validation
-  - Issue: TBD | Size: M | Status: Not Started
-  - Create `particula/particles/particle_data_builder.py`
-  - Implement setter methods with unit conversion
+- [x] **E3-F1-P3**: Create `ParticleDataBuilder` with validation
+  - Issue: TBD | Size: M | Status: Shipped
+  - Created `particula/particles/particle_data_builder.py`
+  - Implemented setter methods with unit conversion (via pint)
   - Auto-add batch dimension if 2D arrays provided
-  - Add validation for positive values, shape compatibility
+  - Validation for positive values, shape compatibility
   - Support zero-initialization via set_n_boxes/particles/species
-  - Write `particula/particles/tests/particle_data_builder_test.py`
+  - Written `particula/particles/tests/particle_data_builder_test.py`
   - Tests for valid builds, unit conversion, validation errors
 
-- [ ] **E3-F1-P4**: Add conversion utilities
-  - Issue: TBD | Size: M | Status: Not Started
-  - Implement `from_representation()` in particle_data.py
-  - Implement `to_representation()` in particle_data.py
-  - Handle all distribution strategy types
-  - Extend test file with conversion round-trip tests
-  - Tests for each strategy type conversion
+- [x] **E3-F1-P4**: Add conversion utilities
+  - Issue: TBD | Size: M | Status: Shipped
+  - Implemented `from_representation()` in particle_data.py
+  - Implemented `to_representation()` in particle_data.py
+  - Handles all 4 distribution strategy types (MassBasedMovingBin,
+    RadiiBasedMovingBin, SpeciatedMassMovingBin,
+    ParticleResolvedSpeciatedMass)
+  - Extended test file with conversion round-trip tests
 
 ## Testing Strategy
 
@@ -456,3 +457,4 @@ Location: `particula/particles/tests/`
 |------|--------|--------|
 | 2026-01-19 | Initial feature document | ADW |
 | 2026-01-19 | Simplified: dropped dataclass_array, added batch dimension, removed array ops | ADW |
+| 2026-02-14 | Marked all phases (P1–P4) shipped after verifying implementation | ADW |

--- a/adw-docs/dev-plans/features/E3-F3-backend-warp-integration.md
+++ b/adw-docs/dev-plans/features/E3-F3-backend-warp-integration.md
@@ -1,27 +1,30 @@
 # Feature E3-F3: Warp Integration and GPU Kernels
 
 **Parent Epic**: [E3: Data Representation Refactor](../epics/E3-data-representation-refactor.md)
-**Status**: Planning
+**Status**: In Progress
 **Priority**: P2
 **Start Date**: TBD
-**Last Updated**: 2026-01-19
+**Last Updated**: 2026-02-14
 
 ## Summary
 
-Integrate NVIDIA Warp for GPU-accelerated particle simulations. Define
-`@wp.struct` for GPU-side data, implement manual transfer control via
-`to_warp()`/`from_warp()`, and create GPU kernels for particle-resolved
-condensation and Brownian coagulation. Designed for multi-box CFD where
-data stays GPU-resident across many timesteps.
+Integrate NVIDIA Warp for GPU-accelerated particle simulations using a
+**bottom-up approach**: first port all underlying physics functions (`get_*`)
+to `@wp.func` with per-function parity tests, then compose them into full
+GPU kernels for condensation and coagulation. Define `@wp.struct` for
+GPU-side data, implement manual transfer control via `to_warp()`/`from_warp()`.
+Designed for multi-box CFD where data stays GPU-resident across many timesteps.
 
 ## Goals
 
-1. Define `@wp.struct WarpParticleData` matching ParticleData batch layout
-2. Implement `to_warp()` with manual control (device, copy options)
-3. Implement `from_warp()` with sync option for explicit transfers
-4. Add `gpu_context()` helper for scoped GPU-resident simulations
-5. Create GPU kernel for particle-resolved condensation
-6. Create GPU kernel for Brownian coagulation
+1. Define `@wp.struct WarpParticleData` and `WarpGasData` matching batch layouts
+2. Implement `to_warp()`/`from_warp()` with manual transfer control
+3. Add `gpu_context()` helper for scoped GPU-resident simulations
+4. Port all underlying `get_*` property functions to `@wp.func` with tests
+   (bottom-up: leaf functions first, then composites)
+5. Assemble full GPU kernels for condensation and coagulation from tested
+   `@wp.func` building blocks
+6. Validate exact numerical parity vs Python/NumPy at every tier
 7. Benchmark and optimize for 100k+ particles per box
 
 ## Non-Goals
@@ -30,6 +33,46 @@ data stays GPU-resident across many timesteps.
 - Automatic/lazy conversion (replaced with explicit manual control)
 - Support for backends other than NumPy and Warp
 - Automatic differentiation (future work)
+
+## Design Principles
+
+### No Approximations: Exact Parity with Python/NumPy
+
+**Every `@wp.kernel` and `@wp.func` must produce numerically identical results
+to the equivalent Python/NumPy function.** The GPU implementation is a parallel
+execution of the _same physics_, not a simplified or approximated version.
+
+- If the Python version uses Fuchs-Sutugin transition regime physics, the Warp
+  kernel uses the exact same formulation.
+- If a Python function exists for a calculation (e.g., `radius_from_mass`,
+  `cunningham_slip_correction`), the Warp `@wp.func` must match it exactly.
+- Tolerance for GPU vs CPU comparison: `rtol=1e-10` (float64 precision).
+
+### Constants from `particula.util.constants` — Never Hardcode
+
+Physical constants (Boltzmann constant, Avogadro number, gas constant, etc.)
+must **never** be written as literal values in `@wp.kernel` or `@wp.func` code.
+Instead:
+
+1. **Pass as kernel parameters** from `particula.util.constants` on the Python
+   side when launching kernels.
+2. **Mathematical constants** like π use the full-precision value
+   `3.141592653589793` (matching `math.pi` exactly) — not truncated values
+   like `3.14159265359`.
+3. **Trivial arithmetic values** (`0.0`, `1.0`, `2.0`, `3.0`, `4.0`) used in
+   formulas are fine as literals since they are not physical constants.
+
+This ensures a single source of truth and makes GPU/CPU parity auditable.
+
+### Testing via Lightweight Wrapper Kernels
+
+Each `@wp.func` is tested by writing a small `@wp.kernel` in the test file
+that calls the function and writes results to an output array. The test then
+compares the GPU output against the equivalent Python/NumPy function using
+`npt.assert_allclose(..., rtol=1e-10)`.
+
+See the [Testing Guide](../../testing_guide.md#testing-nvidia-warp-kernels)
+for the full pattern and checklist.
 
 ## Design
 
@@ -54,10 +97,13 @@ class WarpParticleData:
 
 @wp.struct
 class WarpGasData:
-    """GPU-side gas data container using Warp arrays."""
-    molar_mass: wp.array(dtype=wp.float64)       # (n_species,)
-    concentration: wp.array2d(dtype=wp.float64)   # (n_boxes, n_species)
-    vapor_pressure: wp.array2d(dtype=wp.float64)  # (n_boxes, n_species)
+    """GPU-side gas data container using Warp arrays.
+    
+    Concentration is in kg/m^3, matching the GasData/GasSpecies convention.
+    """
+    molar_mass: wp.array(dtype=wp.float64)       # (n_species,) kg/mol
+    concentration: wp.array2d(dtype=wp.float64)   # (n_boxes, n_species) kg/m^3
+    vapor_pressure: wp.array2d(dtype=wp.float64)  # (n_boxes, n_species) Pa
     partitioning: wp.array(dtype=wp.int32)        # (n_species,) as int for GPU
 ```
 
@@ -197,10 +243,12 @@ def condensation_mass_transfer_kernel(
     masses: wp.array3d(dtype=wp.float64),         # (n_boxes, n_particles, n_species)
     concentration: wp.array2d(dtype=wp.float64),  # (n_boxes, n_particles)
     density: wp.array(dtype=wp.float64),          # (n_species,)
-    # Batched gas data
-    gas_concentration: wp.array2d(dtype=wp.float64),  # (n_boxes, n_species)
-    vapor_pressure: wp.array2d(dtype=wp.float64),     # (n_boxes, n_species)
-    molar_mass: wp.array(dtype=wp.float64),           # (n_species,)
+    # Batched gas data (concentration in kg/m^3, matching GasData convention)
+    gas_concentration: wp.array2d(dtype=wp.float64),  # (n_boxes, n_species) kg/m^3
+    vapor_pressure: wp.array2d(dtype=wp.float64),     # (n_boxes, n_species) Pa
+    molar_mass: wp.array(dtype=wp.float64),           # (n_species,) kg/mol
+    # Physical constants — passed from particula.util.constants, never hardcoded
+    boltzmann_constant: float,  # from BOLTZMANN_CONSTANT
     # Parameters
     temperature: float,
     pressure: float,
@@ -212,6 +260,11 @@ def condensation_mass_transfer_kernel(
     
     2D grid launch: (n_boxes, n_particles)
     Each thread handles one particle in one box.
+    
+    IMPORTANT: Physical constants are passed as kernel parameters from
+    particula.util.constants — they must NOT be hardcoded in kernel code.
+    The physics implemented here must exactly match the Python/NumPy
+    equivalent in particula.dynamics.condensation (no approximations).
     """
     box_idx, particle_idx = wp.tid()
     n_species = masses.shape[2]
@@ -221,18 +274,21 @@ def condensation_mass_transfer_kernel(
         return
     
     # Compute radius from mass and density
+    # Uses PI = 3.141592653589793 (matches math.pi exactly)
+    PI = 3.141592653589793
     total_volume = 0.0
     for s in range(n_species):
         total_volume += masses[box_idx, particle_idx, s] / density[s]
-    radius = wp.pow(3.0 * total_volume / (4.0 * 3.14159265359), 1.0 / 3.0)
+    radius = wp.pow(3.0 * total_volume / (4.0 * PI), 1.0 / 3.0)
     
     # Compute mass transfer for each species
     for s in range(n_species):
-        # Get saturation vapor pressure and gas concentration
+        # Get saturation vapor pressure and gas mass concentration
         p_sat = vapor_pressure[box_idx, s]
-        c_gas = gas_concentration[box_idx, s]
+        c_gas = gas_concentration[box_idx, s]  # kg/m^3
         
         # ... Fuchs-Sutugin or transition regime physics ...
+        # Must match particula.dynamics.condensation Python implementation exactly
         # computed_transfer = ...
         
         mass_transfer[box_idx, particle_idx, s] = 0.0  # TODO: implement condensation mass transfer using proper Fuchs-Sutugin / transition-regime physics
@@ -359,57 +415,181 @@ def condensation_step_gpu(
 
 ## Phase Checklist
 
-- [ ] **E3-F3-P1**: Define `@wp.struct` data containers
-  - Issue: TBD | Size: M | Status: Not Started
-  - Create `particula/gpu/__init__.py` (new module)
-  - Create `particula/gpu/warp_types.py`
-  - Define `WarpParticleData` struct matching ParticleData batch layout
-  - Define `WarpGasData` struct matching GasData batch layout
-  - Write `particula/gpu/tests/warp_types_test.py`
-  - Tests for struct creation, field access
-  - Skip tests if Warp not available
+### Infrastructure (P1–P3) ✅
 
-- [ ] **E3-F3-P2**: Implement `to_warp()` with manual control
-  - Issue: TBD | Size: M | Status: Not Started
-  - Create `particula/gpu/conversion.py`
-  - Implement `to_warp(data, device, copy)` function
-  - Handle device selection, copy vs zero-copy
-  - Add graceful error if Warp not available
-  - Write `particula/gpu/tests/conversion_test.py`
-  - Tests for device transfer, copy modes
+- [x] **E3-F3-P1**: Define `@wp.struct` data containers
+  - Issue: TBD | Size: M | Status: Shipped
+  - Created `particula/gpu/__init__.py` with lazy imports, `WARP_AVAILABLE` sentinel
+  - Created `particula/gpu/warp_types.py`
+  - Defined `WarpParticleData` struct matching ParticleData batch layout
+  - Defined `WarpGasData` struct (excludes name strings, int32 partitioning,
+    added vapor_pressure field for GPU kernels)
+  - Written `particula/gpu/tests/warp_types_test.py` (17 tests)
+  - Tests for struct creation, field shapes, dtypes, field access,
+    single/multi-box, numpy round-trip
+  - All tests skip if Warp not available
+  - **Note**: `WarpGasData.concentration` docstring still says molecules/m³;
+    will be corrected when E3-F2-P4 (kg/m³ revision) is implemented
 
-- [ ] **E3-F3-P3**: Implement `from_warp()` and `gpu_context()`
-  - Issue: TBD | Size: M | Status: Not Started
-  - Implement `from_warp(gpu_data, sync)` function
-  - Implement `gpu_context()` context manager
-  - Write tests for round-trip conversion
-  - Tests for sync behavior, context manager usage
+- [x] **E3-F3-P2**: Implement `to_warp()` with manual control
+  - Issue: TBD | Size: M | Status: Shipped
+  - Created `particula/gpu/conversion.py`
+  - Implemented `to_warp_particle_data(data, device, copy)` and
+    `to_warp_gas_data(data, device, copy, vapor_pressure)` functions
+  - Handles device selection, copy vs zero-copy (wp.from_numpy),
+    graceful RuntimeError if Warp not available, device validation
+  - Written `particula/gpu/tests/conversion_test.py`
+  - Tests for default transfer, shape preservation, value integrity,
+    copy independence, zero-copy, device selection, invalid device error
 
-- [ ] **E3-F3-P4**: GPU kernel for particle-resolved condensation
+- [x] **E3-F3-P3**: Implement `from_warp()` and `gpu_context()`
+  - Issue: TBD | Size: M | Status: Shipped
+  - Implemented `from_warp_particle_data(gpu_data, sync)` and
+    `from_warp_gas_data(gpu_data, name, sync)` functions
+  - Implemented `gpu_context()` context manager
+  - Handles sync behavior, placeholder name generation for gas data,
+    bool↔int32 partitioning conversion, name length validation
+  - Tests for round-trip conversion, sync true/false, context manager
+    usage (transfer inside/after context, simulation loop pattern),
+    multi-box scenarios, error handling
+
+### Tier 1 — Leaf Physics Functions as `@wp.func` (P4–P5)
+
+These are the foundational building blocks shared by both condensation and
+coagulation. Each `@wp.func` is a direct port of an existing Python function.
+Every function is tested via a lightweight wrapper `@wp.kernel` that compares
+GPU output against the Python/NumPy equivalent with `rtol=1e-10`.
+
+- [ ] **E3-F3-P4**: Port shared gas/particle property functions to `@wp.func`
   - Issue: TBD | Size: L | Status: Not Started
-  - Create `particula/gpu/kernels/condensation.py`
-  - Implement `condensation_mass_transfer_kernel`
-  - Implement `apply_mass_transfer_kernel`
-  - Create `condensation_step_gpu()` high-level function
-  - Write `particula/gpu/kernels/tests/condensation_test.py`
-  - Tests comparing GPU vs CPU results (numerical equivalence)
+  - Create `particula/gpu/properties/__init__.py`
+  - Create `particula/gpu/properties/gas_properties.py`:
+    - `dynamic_viscosity_wp` ← `get_dynamic_viscosity`
+      (Sutherland formula; constants `REF_VISCOSITY_AIR_STP`,
+      `REF_TEMPERATURE_STP`, `SUTHERLAND_CONSTANT` passed as params)
+    - `molecule_mean_free_path_wp` ← `get_molecule_mean_free_path`
+      (depends on viscosity; `GAS_CONSTANT`, `MOLECULAR_WEIGHT_AIR` as params)
+    - `partial_pressure_wp` ← `get_partial_pressure`
+      (`GAS_CONSTANT` as param)
+  - Create `particula/gpu/properties/particle_properties.py`:
+    - `knudsen_number_wp` ← `get_knudsen_number` (pure division)
+    - `cunningham_slip_correction_wp` ← `get_cunningham_slip_correction`
+      (empirical coefficients 1.257, 0.4, 1.1 are model-specific constants,
+      not physical constants — acceptable as literals with comment)
+    - `aerodynamic_mobility_wp` ← `get_aerodynamic_mobility` (uses π)
+    - `mean_thermal_speed_wp` ← `get_mean_thermal_speed`
+      (`BOLTZMANN_CONSTANT` as param)
+    - `friction_factor_wp` ← `get_friction_factor` (uses π)
+  - Write `particula/gpu/properties/tests/gas_properties_test.py`
+  - Write `particula/gpu/properties/tests/particle_properties_test.py`
+  - Each test: wrapper `@wp.kernel` → compare vs Python function
+  - Test on `"cpu"` (always) and `"cuda"` (skip if unavailable)
 
-- [ ] **E3-F3-P5**: GPU kernel for Brownian coagulation
+- [ ] **E3-F3-P5**: Port condensation-specific property functions to `@wp.func`
+  - Issue: TBD | Size: M | Status: Not Started
+  - Add to `particula/gpu/properties/particle_properties.py`:
+    - `vapor_transition_correction_wp` ← `get_vapor_transition_correction`
+      (Fuchs-Sutugin; coefficients 0.75, 0.283 are model-specific)
+    - `kelvin_radius_wp` ← `get_kelvin_radius`
+      (`GAS_CONSTANT` as param)
+    - `kelvin_term_wp` ← `get_kelvin_term` (with safe exp clamping)
+    - `partial_pressure_delta_wp` ← `get_partial_pressure_delta`
+  - Add to `particula/gpu/properties/tests/particle_properties_test.py`
+  - Each test: wrapper kernel → compare vs Python equivalent
+
+### Tier 2 — Composite Functions as `@wp.func` (P6–P7)
+
+These compose the Tier 1 functions into the intermediate calculations that
+the full condensation and coagulation kernels require.
+
+- [ ] **E3-F3-P6**: Port condensation composite functions to `@wp.func`
+  - Issue: TBD | Size: M | Status: Not Started
+  - Create `particula/gpu/dynamics/__init__.py`
+  - Create `particula/gpu/dynamics/condensation_funcs.py`:
+    - `first_order_mass_transport_k_wp` ← `get_first_order_mass_transport_k`
+      (4πrDX; combines radius, vapor transition, diffusion coefficient)
+    - `mass_transfer_rate_wp` ← `get_mass_transfer_rate`
+      (K·Δp·M/(R·T); `GAS_CONSTANT` as param)
+    - `diffusion_coefficient_wp` ← `get_diffusion_coefficient`
+      (`BOLTZMANN_CONSTANT` as param; Stokes-Einstein D = kB·T·B)
+  - Write `particula/gpu/dynamics/tests/condensation_funcs_test.py`:
+    - Wrapper kernels for each `@wp.func`
+    - Compare vs Python: `get_first_order_mass_transport_k`,
+      `get_mass_transfer_rate`, `get_diffusion_coefficient`
+    - Chained test: full condensation rate from raw inputs through
+      all tiers, compared against `CondensationIsothermal.mass_transfer_rate`
+
+- [ ] **E3-F3-P7**: Port coagulation composite functions to `@wp.func`
+  - Issue: TBD | Size: M | Status: Not Started
+  - Create `particula/gpu/dynamics/coagulation_funcs.py`:
+    - `brownian_diffusivity_wp` ← `_brownian_diffusivity`
+      (`BOLTZMANN_CONSTANT` as param)
+    - `particle_mean_free_path_wp` ← `_mean_free_path_l` (uses π)
+    - `g_collection_term_wp` ← `_g_collection_term`
+      (Fuchs collection distance formula)
+    - `brownian_kernel_pair_wp` ← per-pair form of `get_brownian_kernel`
+      (Fuchs form: 4π(D₁+D₂)(r₁+r₂)/denominator — scalar pair version
+      suitable for GPU thread-per-pair)
+  - Write `particula/gpu/dynamics/tests/coagulation_funcs_test.py`:
+    - Wrapper kernels for each `@wp.func`
+    - Compare vs Python equivalents
+    - Chained test: full Brownian kernel for a pair of particles from
+      raw inputs through all tiers, compared against
+      `get_brownian_kernel_via_system_state` for same pair
+
+### Tier 3 — Full GPU Kernels (P8–P9)
+
+These compose the `@wp.func` functions from P4–P7 into batched GPU kernels.
+All physics is already ported and tested — these phases focus on the kernel
+launch patterns, batch dimensions, and integration.
+
+- [ ] **E3-F3-P8**: Batched GPU kernel for particle-resolved condensation
   - Issue: TBD | Size: L | Status: Not Started
-  - Create `particula/gpu/kernels/coagulation.py`
-  - Implement `brownian_coagulation_kernel`
-  - Create `coagulation_step_gpu()` high-level function
-  - Write `particula/gpu/kernels/tests/coagulation_test.py`
-  - Tests comparing GPU vs CPU results (statistical equivalence)
+  - Create `particula/gpu/kernels/__init__.py`
+  - Create `particula/gpu/kernels/condensation.py`:
+    - `condensation_mass_transfer_kernel`: 2D launch (n_boxes, n_particles),
+      calls `@wp.func`s from P4–P6 to compute per-particle mass transfer
+    - `apply_mass_transfer_kernel`: clamp masses to non-negative
+    - `condensation_step_gpu()`: high-level function that orchestrates
+      kernel launches, passes constants from `util.constants`
+  - Write `particula/gpu/kernels/tests/condensation_test.py`:
+    - End-to-end test: create ParticleData + GasData, run GPU step,
+      compare vs Python `CondensationIsothermal` on same inputs
+    - `npt.assert_allclose(gpu_result, cpu_result, rtol=1e-10)`
+    - Test with n_boxes=1 and n_boxes>1
+    - Test mass clamping (no negative masses)
+    - Test inactive particle skipping (concentration=0)
 
-- [ ] **E3-F3-P6**: Benchmark and optimize GPU kernels
+- [ ] **E3-F3-P9**: Batched GPU kernel for Brownian coagulation
+  - Issue: TBD | Size: L | Status: Not Started
+  - Create `particula/gpu/kernels/coagulation.py`:
+    - `brownian_coagulation_kernel`: 1D launch (n_boxes), box-level
+      Monte Carlo process using `@wp.func`s from P4–P7 plus Warp RNG
+    - `coagulation_step_gpu()`: high-level function
+  - Write `particula/gpu/kernels/tests/coagulation_test.py`:
+    - Kernel matrix test: compute full NxN kernel matrix via GPU,
+      compare against `get_brownian_kernel_via_system_state`
+    - Statistical test: run many coagulation steps with fixed seed,
+      verify expected collision count distribution
+    - Test with n_boxes > 1
+
+### Benchmarks (P10) and Documentation (P11)
+
+- [ ] **E3-F3-P10**: Benchmark and optimize GPU kernels
   - Issue: TBD | Size: M | Status: Not Started
   - Create `particula/gpu/tests/benchmark_test.py`
-  - Benchmark condensation: 1 box x 100k particles, 100 boxes x 1k particles
+  - Benchmark condensation: 1 box × 100k particles, 100 boxes × 1k particles
   - Benchmark coagulation: same configurations
+  - Benchmark individual `@wp.func` vs NumPy equivalents
   - Optimize memory access patterns if needed
   - Document performance characteristics
   - Mark as `@pytest.mark.slow` and `@pytest.mark.performance`
+
+- [ ] **E3-F3-P11**: Update development documentation
+  - Issue: TBD | Size: XS | Status: Not Started
+  - Update index.md and README.md with final status
+  - Add completion notes and lessons learned
+  - Update E3 epic with final phase outcomes
 
 ## Testing Strategy
 
@@ -417,33 +597,61 @@ def condensation_step_gpu(
 
 Location: `particula/gpu/tests/`
 
-| Test File | Coverage Target |
-|-----------|----------------|
-| `warp_types_test.py` | WarpParticleData, WarpGasData structs |
-| `conversion_test.py` | to_warp(), from_warp(), gpu_context() |
+| Test File | Coverage Target | Phase |
+|-----------|----------------|-------|
+| `warp_types_test.py` | WarpParticleData, WarpGasData structs | P1 |
+| `conversion_test.py` | to_warp(), from_warp(), gpu_context() | P2–P3 |
+
+Location: `particula/gpu/properties/tests/`
+
+| Test File | Coverage Target | Phase |
+|-----------|----------------|-------|
+| `gas_properties_test.py` | dynamic_viscosity_wp, molecule_mean_free_path_wp, partial_pressure_wp | P4 |
+| `particle_properties_test.py` | knudsen_number_wp, slip_correction_wp, aerodynamic_mobility_wp, mean_thermal_speed_wp, friction_factor_wp, vapor_transition_wp, kelvin_radius_wp, kelvin_term_wp, pressure_delta_wp | P4–P5 |
+
+Location: `particula/gpu/dynamics/tests/`
+
+| Test File | Coverage Target | Phase |
+|-----------|----------------|-------|
+| `condensation_funcs_test.py` | first_order_mass_transport_k_wp, mass_transfer_rate_wp, diffusion_coefficient_wp + chained condensation rate test | P6 |
+| `coagulation_funcs_test.py` | brownian_diffusivity_wp, particle_mean_free_path_wp, g_collection_term_wp, brownian_kernel_pair_wp + chained kernel test | P7 |
 
 Location: `particula/gpu/kernels/tests/`
 
-| Test File | Coverage Target |
-|-----------|----------------|
-| `condensation_test.py` | GPU condensation kernel vs CPU |
-| `coagulation_test.py` | GPU coagulation kernel vs CPU |
-| `benchmark_test.py` | Performance benchmarks (slow) |
+| Test File | Coverage Target | Phase |
+|-----------|----------------|-------|
+| `condensation_test.py` | End-to-end batched condensation kernel vs CPU CondensationIsothermal | P8 |
+| `coagulation_test.py` | End-to-end batched coagulation kernel vs CPU Brownian kernel | P9 |
+| `benchmark_test.py` | Performance benchmarks (slow) | P10 |
 
 ### Test Approach
 
 1. **Skip if No Warp**: All GPU tests use `pytest.importorskip("warp")`
-2. **Numerical Equivalence**: GPU results match CPU within tolerance (1e-10)
-3. **Round-Trip**: `from_warp(to_warp(data))` equals original
-4. **Multi-Box**: Test with n_boxes > 1 to verify batch dimension
-5. **Performance**: GPU achieves 10x+ speedup for 100k particles
+2. **Lightweight Wrapper Kernels**: Each `@wp.func` is tested via a small
+   `@wp.kernel` in the test file that calls the function and writes results
+   to an output array — then compared against the Python/NumPy equivalent
+3. **Exact Numerical Parity**: GPU results must match CPU within float64
+   precision: `npt.assert_allclose(gpu, cpu, rtol=1e-10)` — no approximations
+4. **No Hardcoded Constants**: Tests verify that kernel code uses constants
+   from `particula.util.constants` (passed as parameters), not literal values
+5. **Round-Trip**: `from_warp(to_warp(data))` equals original
+6. **Multi-Box**: Test with n_boxes > 1 to verify batch dimension
+7. **Dual Device**: Test on `"cpu"` (always available) and `"cuda"` (skipped
+   if unavailable)
+8. **Performance**: GPU achieves 10x+ speedup for 100k particles (benchmark
+   tests only, marked `@pytest.mark.slow`)
 
 ## Dependencies
 
 - `numpy>=2.0.0` (existing)
 - `nvidia-warp>=1.0.0` (optional, for GPU features)
-- E3-F1: ParticleData (for conversion)
-- E3-F2: GasData (for conversion)
+- E3-F1: ParticleData (for conversion, P1–P3)
+- E3-F2: GasData (for conversion, P1–P3)
+- `particula.gas.properties` — Python reference functions for P4 parity tests
+- `particula.particles.properties` — Python reference functions for P4–P5 parity tests
+- `particula.dynamics.condensation` — Python reference for P6, P8 parity tests
+- `particula.dynamics.coagulation` — Python reference for P7, P9 parity tests
+- `particula.util.constants` — single source of truth for all physical constants
 
 ## Risks and Mitigations
 
@@ -452,17 +660,24 @@ Location: `particula/gpu/kernels/tests/`
 | Warp not installed | Optional dependency, skip GPU tests, document installation |
 | GPU memory limits | Document max particles, batch processing for huge datasets |
 | Numerical precision | Use float64, compare with tolerance, document precision |
-| Kernel complexity | Start with simple physics, optimize iteratively |
+| Kernel complexity | Bottom-up approach: port+test leaf functions first, compose later |
+| NxN matrix operations in Warp | `brownian_kernel_pair_wp` is scalar-pair form; NxN assembly done by 2D kernel launch |
+| `scipy.interpolate` in particle-resolved coag | Need Warp-native interpolation or pre-computed lookup table; may defer to future phase |
 | Multi-GPU | Start with single GPU, add multi-GPU in future |
 
 ## Success Criteria
 
 1. `@wp.struct` definitions match ParticleData/GasData layout
 2. `to_warp()`/`from_warp()` round-trip preserves data exactly
-3. GPU kernels produce numerically equivalent results to CPU
-4. Multi-box (n_boxes > 1) works correctly
-5. GPU achieves 10x+ speedup for 100k particles per box
-6. All tests pass (skip gracefully if Warp unavailable)
+3. GPU kernels produce **exact numerical parity** with Python/NumPy
+   equivalents (`rtol=1e-10`) — no approximations or shortcuts
+4. No hardcoded physical constants in any `@wp.kernel` or `@wp.func` — all
+   sourced from `particula.util.constants`
+5. Every `@wp.func` tested via lightweight wrapper kernel compared against
+   the equivalent Python function
+6. Multi-box (n_boxes > 1) works correctly
+7. GPU achieves 10x+ speedup for 100k particles per box
+8. All tests pass (skip gracefully if Warp unavailable)
 
 ## Change Log
 
@@ -470,3 +685,7 @@ Location: `particula/gpu/kernels/tests/`
 |------|--------|--------|
 | 2026-01-19 | Initial feature document | ADW |
 | 2026-01-19 | Replaced ArrayBackend with manual transfer control, added batch dimension | ADW |
+| 2026-02-14 | Updated WarpGasData and kernel docs to reflect kg/m³ concentration (aligns with E3-F2-P4 revision) | ADW |
+| 2026-02-14 | Added Design Principles: exact parity, no hardcoded constants, lightweight wrapper kernel testing | ADW |
+| 2026-02-14 | Expanded from 6 to 11 phases: bottom-up @wp.func porting (P4–P7) before kernel assembly (P8–P9) | ADW |
+| 2026-02-14 | Marked P1–P3 shipped after verifying implementation matches plan | ADW |

--- a/adw-docs/dev-plans/features/index.md
+++ b/adw-docs/dev-plans/features/index.md
@@ -9,9 +9,9 @@ work, typically ~100 LOC per phase, that deliver user-facing functionality.
 
 | ID | Name | Status | Priority | Phases |
 |----|------|--------|----------|--------|
-| E3-F1 | [Particle Data Container](E3-F1-particle-data-container.md) | Planning | P1 | 4 |
-| E3-F2 | [Gas Data Container](E3-F2-gas-data-container.md) | Planning | P1 | 3 |
-| E3-F3 | [Warp Integration and GPU Kernels](E3-F3-backend-warp-integration.md) | Planning | P2 | 6 |
+| E3-F1 | [Particle Data Container](E3-F1-particle-data-container.md) | Shipped | P1 | 4 |
+| E3-F2 | [Gas Data Container](E3-F2-gas-data-container.md) | In Progress | P1 | 4 |
+| E3-F3 | [Warp Integration and GPU Kernels](E3-F3-backend-warp-integration.md) | In Progress | P2 | 11 |
 | E3-F4 | [Facade and Migration](E3-F4-facade-migration.md) | Planning | P1 | 5 |
 
 ### Standalone Features (Wall Loss)

--- a/docs/Theory/nvidia-warp/datastructures.md
+++ b/docs/Theory/nvidia-warp/datastructures.md
@@ -139,6 +139,7 @@ def build_coagulation_matrix(
     kernel_matrix: wp.array2d(dtype=float),
     temperature: float,
     viscosity: float,
+    k_boltzmann: float,  # from particula.util.constants.BOLTZMANN_CONSTANT
 ):
     """Build pairwise coagulation kernel matrix K[i,j]."""
     i, j = wp.tid()
@@ -147,8 +148,7 @@ def build_coagulation_matrix(
     d_j = diameters[j]
     
     # Brownian coagulation kernel
-    k_B = 1.380649e-23
-    K_ij = (2.0 * k_B * temperature / (3.0 * viscosity)) * \
+    K_ij = (2.0 * k_boltzmann * temperature / (3.0 * viscosity)) * \
            (d_i + d_j) * (1.0/d_i + 1.0/d_j)
     
     kernel_matrix[i, j] = K_ij

--- a/docs/Theory/nvidia-warp/examples/geometry.md
+++ b/docs/Theory/nvidia-warp/examples/geometry.md
@@ -180,8 +180,9 @@ Wall loss is the deposition of particles on chamber surfaces due to diffusion, s
 ### Diffusion-Limited Wall Loss
 
 ```python
-K_B = 1.380649e-23  # Boltzmann constant
-PI = 3.14159265359
+# Physical constants — in practice, pass from particula.util.constants
+# as kernel parameters. Module-level constants shown here for brevity.
+PI = 3.141592653589793  # matches math.pi exactly
 
 @wp.func
 def diffusion_wall_loss_rate_sphere(


### PR DESCRIPTION
**Target Branch:** `main`

## Summary

Comprehensive revision of the E3 (Data Representation Refactor) development plans to reflect current implementation status and an expanded, bottom-up GPU integration strategy. Updates shipping status for completed features, adds new design principles for GPU/CPU parity, and expands the Warp integration roadmap from 6 to 11 phases.

## What Changed

### Updated Documents

- **`adw-docs/dev-plans/epics/E3-data-representation-refactor.md`** — Updated feature status table (E3-F1 Shipped, E3-F2/F3 In Progress), expanded phase overview from ~20 to ~26 phases, added GPU/Warp testing rules (exact parity, no hardcoded constants, wrapper kernel testing), updated kernel examples with constants-as-parameters pattern and kg/m3 units

- **`adw-docs/dev-plans/features/E3-F1-particle-data-container.md`** — Marked all 4 phases (P1-P4) as Shipped with implementation notes

- **`adw-docs/dev-plans/features/E3-F2-gas-data-container.md`** — Marked P1-P3 as Shipped, added new P4 phase for concentration unit revision (molecules/m3 to kg/m3) with detailed line-by-line change instructions

- **`adw-docs/dev-plans/features/E3-F3-backend-warp-integration.md`** — Major expansion: added Design Principles section, marked P1-P3 Shipped, expanded from 6 to 11 phases with tiered bottom-up strategy (Tier 1: leaf wp.func ports, Tier 2: composite wp.func ports, Tier 3: full batched GPU kernels)

- **`adw-docs/dev-plans/features/index.md`** — Updated status for E3-F1 (Shipped), E3-F2 (In Progress), E3-F3 (In Progress)

- **`adw-docs/testing_guide.md`** — Added new section on testing NVIDIA Warp kernels with full pattern, checklist, and wrapper kernel examples

### Theory Documentation

- **`docs/Theory/nvidia-warp/kernels.md`** — Expanded with detailed wp.func bottom-up porting strategy and testing patterns
- **`docs/Theory/nvidia-warp/datastructures.md`** — Minor unit annotation updates (kg/m3)
- **`docs/Theory/nvidia-warp/examples/fluids.md`** — Updated to reflect kg/m3 concentration convention
- **`docs/Theory/nvidia-warp/examples/geometry.md`** — Minor consistency fixes

## How It Works

The key architectural decision is the bottom-up GPU porting strategy:

```
Tier 1: Leaf @wp.func (P4-P5)
    |-- gas_properties.py: viscosity, mean_free_path, partial_pressure
    |-- particle_properties.py: knudsen, slip_correction, mobility
    |-- Each tested via wrapper @wp.kernel vs Python equivalent (rtol=1e-10)

Tier 2: Composite @wp.func (P6-P7)
    |-- condensation_funcs.py: mass_transport_k, transfer_rate, diffusion_coeff
    |-- coagulation_funcs.py: brownian_diffusivity, mean_free_path, kernel_pair
    |-- Chained parity tests vs CondensationIsothermal / Brownian kernel

Tier 3: Full GPU Kernels (P8-P9)
    |-- condensation.py: batched 2D kernel (n_boxes x n_particles)
    |-- coagulation.py: batched 1D kernel (n_boxes) with Monte Carlo
```

This ensures every physics function is individually verified before composition into full kernels, eliminating debugging complexity.

## Implementation Notes

- **Why bottom-up**: Previous 6-phase plan jumped directly to full kernels. This revision ensures each physics function is individually tested for GPU/CPU parity before assembly, making bugs traceable to specific functions.
- **Why kg/m3**: The existing GasSpecies convention uses kg/m3. The original GasData used molecules/m3, requiring Avogadro conversions. E3-F2-P4 eliminates this mismatch.
- **Constants policy**: All physical constants passed as kernel parameters from particula.util.constants, never hardcoded in GPU code.

## Testing

- **No code changes** — this PR is documentation-only
- All existing tests continue to pass unchanged
- New testing patterns documented in testing_guide.md for future GPU implementation phases