### PR TITLE
fix: #1076 - Fix MathJax configuration for math rendering across all pages including notebooks

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,5 +1,25 @@
 window.MathJax = {
   tex: {
-    inlineMath: {'[+]': [['$', '$']]}
-  }
+    inlineMath: [
+      ["\\(", "\\)"],
+      ["$", "$"],
+    ],
+    displayMath: [
+      ["\\[", "\\]"],
+      ["$$", "$$"],
+    ],
+    processEscapes: true,
+    processEnvironments: true,
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex|jp-RenderedHTMLCommon|jp-RenderedMarkdown",
+  },
 };
+
+document$.subscribe(() => {
+  MathJax.startup.output.clearCache();
+  MathJax.typesetClear();
+  MathJax.texReset();
+  MathJax.typesetPromise();
+});


### PR DESCRIPTION
**Target Branch:** `main`

**Fixes #1076** | Workflow: `a0344106`

## Summary

Replaces the MathJax setup with the full 4.x configuration so math renders reliably across Markdown pages and Jupyter-rendered notebooks. The new config adds the recommended inline/display delimiters, escape/environment handling, and restricts processing to math-marked elements. It also hooks into `document$` so math re-typesets after mkdocs-material instant navigation.

## What Changed

### Modified Components  
- `docs/javascripts/mathjax.js` – Replaced minimal config with full MathJax 4 setup, added processing allowlist, and subscribed to `document$` to clear caches and re-typeset on navigation.

### Tests Added/Updated  
- None (static JS configuration); manual mkdocs verification recommended.

## How It Works

- `tex` config now includes both `\(...\)`/`\[...\]` and `$...$`/`$$...$$`, plus `processEscapes` and `processEnvironments`, covering arithmatex-wrapped Markdown and raw notebook math.  
- `options.ignoreHtmlClass = ".*|"` with `processHtmlClass = "arithmatex|jp-RenderedHTMLCommon|jp-RenderedMarkdown"` limits MathJax to known math containers, avoiding false positives in code blocks.  
- `document$.subscribe()` clears MathJax caches and re-runs `typesetPromise()` after instant navigation so math persists between pages.

## Implementation Notes

- Allowlisting via `processHtmlClass` prevents MathJax from scanning non-math content and improves performance.  
- Subscription uses the mkdocs-material observable to keep math rendering after SPA-style navigation.  
- Configuration matches MathJax 4.x loader already included in `mkdocs.yml`.

## Testing

- Not run in this step (static JS config). Manual checks recommended: `mkdocs serve` for Markdown and notebook pages, and `mkdocs build` for full site build.
