### PR TITLE
fix: #1089 - [M5-P3] Documentation and cleanup for charged coagulation kernel fixes

### DIFF
--- a/adw-docs/dev-plans/maintenance/M5-charged-coagulation-kernel-bugs.md
+++ b/adw-docs/dev-plans/maintenance/M5-charged-coagulation-kernel-bugs.md
@@ -2,8 +2,8 @@
 
 **ID:** M5
 **Priority:** P1
-**Status:** Planning
-**Last Updated:** 2026-02-23
+**Status:** Shipped
+**Last Updated:** 2026-02-24
 
 ## Vision
 
@@ -346,3 +346,4 @@ kinetic_enhance → 0 issue from Bug 1.
 | 2026-02-23 | Initial maintenance plan created | ADW Workflow |
 | 2026-02-23 | Corrected root cause analysis (kinetic_enhance→0, not reduced_mass→0); upgraded P2 to size M; added kernel NaN/Inf success criterion; strengthened P3 investigation on charge-blind interpolation; added duplicate code cleanup to P4 | ADW Review |
 | 2026-02-23 | Restructured phases: merged test-writing into fix phases so no failing tests are committed. P1 = fix NaN + tests, P2 = fix spurious coagulation + tests, P3 = cleanup. Removed standalone reproducer-tests phase. | Manual |
+| 2026-02-24 | Shipped P3 cleanup (removed dead code, verified no diagnostic logging). | ADW Workflow |

--- a/particula/dynamics/coagulation/charged_dimensional_kernel.py
+++ b/particula/dynamics/coagulation/charged_dimensional_kernel.py
@@ -189,18 +189,6 @@ def get_hard_sphere_kernel_via_system_state(
     # Ensure dimensionless_kernel is an array
     dimensionless_kernel = np.atleast_1d(dimensionless_kernel_raw)
 
-    # Ensure dimensionless_kernel is an array
-    dimensionless_kernel = np.atleast_1d(dimensionless_kernel_raw)
-
-    # Ensure dimensionless_kernel is an array
-    dimensionless_kernel = np.atleast_1d(dimensionless_kernel_raw)
-
-    # Ensure dimensionless_kernel is an array
-    dimensionless_kernel = np.atleast_1d(dimensionless_kernel_raw)
-
-    # Ensure dimensionless_kernel is an array
-    dimensionless_kernel = np.atleast_1d(dimensionless_kernel_raw)
-
     return get_dimensional_kernel(
         dimensionless_kernel=dimensionless_kernel,
         coulomb_potential_ratio=coulomb_potential_ratio,
@@ -268,13 +256,6 @@ def get_coulomb_kernel_dyachkov2007_via_system_state(
     # Ensure dimensionless_kernel is an array
     dimensionless_kernel = np.atleast_1d(dimensionless_kernel_raw)
 
-    return get_dimensional_kernel(
-        dimensionless_kernel=dimensionless_kernel,
-        coulomb_potential_ratio=coulomb_potential_ratio,
-        sum_of_radii=sum_of_radii,
-        reduced_mass=reduced_mass,
-        reduced_friction_factor=reduced_friction_factor,
-    )
     return get_dimensional_kernel(
         dimensionless_kernel=dimensionless_kernel,
         coulomb_potential_ratio=coulomb_potential_ratio,

--- a/particula/dynamics/coagulation/tests/charge_dimensional_kernel_test.py
+++ b/particula/dynamics/coagulation/tests/charge_dimensional_kernel_test.py
@@ -5,6 +5,7 @@ via system state.
 import numpy as np
 import pytest
 from particula.dynamics.coagulation.charged_dimensional_kernel import (
+    _system_state_properties,
     get_coulomb_kernel_chahl2019_via_system_state,
     get_coulomb_kernel_dyachkov2007_via_system_state,
     get_coulomb_kernel_gatti2008_via_system_state,
@@ -36,3 +37,86 @@ def test_dimensioned_coagulation_kernels_array(kernel_function):
     kernel_matrix = kernel_function(radii, mass, charge, temperature, pressure)
     assert kernel_matrix.shape == (3, 3)
     assert np.all(np.isfinite(kernel_matrix))
+
+
+def test_system_state_properties_scalar_outputs():
+    """Test scalar inputs return expected shapes and reduced mass."""
+    radius = 1.2e-9
+    mass = 2.4e-18
+    charge = 1.0
+    temperature = 300.0
+    pressure = 101325.0
+
+    (
+        coulomb_potential_ratio,
+        diffusive_knudsen,
+        sum_of_radii,
+        reduced_mass,
+        reduced_friction_factor,
+    ) = _system_state_properties(
+        particle_radius=radius,
+        particle_mass=mass,
+        particle_charge=charge,
+        temperature=temperature,
+        pressure=pressure,
+    )
+
+    assert coulomb_potential_ratio.shape == (1,)
+    assert diffusive_knudsen.shape == (1,)
+    assert sum_of_radii.shape == (1, 1)
+    assert reduced_mass.shape == (1, 1)
+    assert reduced_friction_factor.shape == (1, 1)
+
+    np.testing.assert_allclose(sum_of_radii, np.array([[2 * radius]]))
+    np.testing.assert_allclose(reduced_mass, np.array([[mass / 2.0]]))
+    assert np.all(np.isfinite(coulomb_potential_ratio))
+    assert np.all(np.isfinite(diffusive_knudsen))
+
+
+def test_system_state_properties_array_outputs():
+    """Test array inputs broadcast to square matrices."""
+    radius = np.array([1.0e-9, 2.0e-9])
+    mass = np.array([1.0e-18, 3.0e-18])
+    charge = np.array([0.0, 1.0])
+    temperature = 300.0
+    pressure = 101325.0
+
+    (
+        coulomb_potential_ratio,
+        diffusive_knudsen,
+        sum_of_radii,
+        reduced_mass,
+        reduced_friction_factor,
+    ) = _system_state_properties(
+        particle_radius=radius,
+        particle_mass=mass,
+        particle_charge=charge,
+        temperature=temperature,
+        pressure=pressure,
+    )
+
+    assert coulomb_potential_ratio.shape == (2, 2)
+    assert diffusive_knudsen.shape == (2, 2)
+    assert sum_of_radii.shape == (2, 2)
+    assert reduced_mass.shape == (2, 2)
+    assert reduced_friction_factor.shape == (2, 2)
+
+    expected_sum = np.array(
+        [
+            [2.0e-9, 3.0e-9],
+            [3.0e-9, 4.0e-9],
+        ]
+    )
+    expected_reduced_mass = np.array(
+        [
+            [0.5e-18, 0.75e-18],
+            [0.75e-18, 1.5e-18],
+        ]
+    )
+    np.testing.assert_allclose(sum_of_radii, expected_sum)
+    np.testing.assert_allclose(reduced_mass, expected_reduced_mass)
+    np.testing.assert_allclose(
+        coulomb_potential_ratio, coulomb_potential_ratio.T
+    )
+    assert np.all(np.isfinite(reduced_friction_factor))
+    assert np.all(np.isfinite(diffusive_knudsen))


### PR DESCRIPTION
**Target Branch:** `main`

**Fixes #1089** | Workflow: `4630f5da`

## Summary

Cleans up the charged coagulation kernels by removing duplicate code paths and updating the maintenance record for M5-P3. Adds regression coverage to ensure system-state kernels return finite, correctly shaped outputs for both scalar and array inputs.

## What Changed

### New Components
- `particula/dynamics/coagulation/tests/charge_dimensional_kernel_test.py` – regression tests exercising all charged/system-state kernel wrappers and the shared system-state property helper for scalar and array inputs.

### Modified Components
- `particula/dynamics/coagulation/charged_dimensional_kernel.py` – collapsed redundant `np.atleast_1d` calls in `get_hard_sphere_kernel_via_system_state` and removed the unreachable duplicate return in `get_coulomb_kernel_dyachkov2007_via_system_state`.
- `adw-docs/dev-plans/maintenance/M5-charged-coagulation-kernel-bugs.md` – marked the maintenance plan as Shipped and recorded the P3 cleanup in the changelog.

### Tests Added/Updated
- `charge_dimensional_kernel_test.py` – validates kernel matrix shapes/finitemess across all charged/system-state kernels and verifies helper broadcasting for scalar and array inputs.

## How It Works

- The hard-sphere system-state wrapper now makes a single array coercion before dimensional conversion, removing four no-op duplicates.
- The Dyachkov (2007) system-state wrapper retains a single dimensional conversion return, eliminating unreachable dead code.
- New tests cover system-state property broadcasting (scalars → 1×1 matrices, arrays → square matrices) and ensure all kernel wrappers return finite values.
- The maintenance plan reflects completion of the cleanup phase.

## Implementation Notes

- Changes are limited to dead-code removal and documentation status update; no behavioral changes expected beyond eliminating redundant array coercions.
- Added regression coverage to guard against future regressions in system-state broadcasting and kernel finiteness.

## Testing

- `pytest particula/dynamics/coagulation/tests/charge_dimensional_kernel_test.py`
- `pytest --cov=particula --cov-report=term-missing`
- `pytest -Werror`
- `ruff check particula/ && ruff format --check particula/`