### PR TITLE
ci: always build docs on push to main

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'docs/**'
   merge_group:
     branches: [ main ]
 


### PR DESCRIPTION
**Target Branch:** `main`

## Summary

Removes the `paths` filter from the mkdocs workflow so documentation is always built on push to `main`, not only when files under `docs/` change.

Previously, the mkdocs workflow only triggered on pushes that modified `docs/**`. This meant that changes to source code (e.g., docstrings, module structure, API signatures) would not rebuild the documentation site, causing the published docs to go stale until the next `docs/` change.

## What Changed

### Modified Components

- `.github/workflows/mkdocs.yml` — Removed the `paths: ['docs/**']` filter from the `push` trigger

### Diff

```yaml
  push:
    branches:
      - main
-   paths:
-     - 'docs/**'
```

## Why

The docs site is built with **mkdocstrings**, which auto-generates API reference from Python source code. Any change to the codebase (new functions, renamed parameters, updated docstrings) can affect the rendered docs. Restricting the build to `docs/` changes only caused the published site to drift out of sync with the actual code.

Removing the path filter ensures every push to `main` rebuilds and deploys up-to-date documentation.

## Impact

- **CI cost**: Minimal — the mkdocs build is lightweight and already has concurrency control (`cancel-in-progress: true`)
- **No code changes**: Only a workflow configuration update
- **`pull_request` and `merge_group` triggers**: Unchanged — they already had no path filter