### PR TITLE
feat: #1125 - [E5-F1-P4] Add latent heat factory and gas exports with tests

### DIFF
--- a/adw-docs/dev-plans/README.md
+++ b/adw-docs/dev-plans/README.md
@@ -70,7 +70,7 @@ and rollout.
 
 ### Epic E5: Non-Isothermal Condensation Features
 
-- [E5-F1: Latent Heat Strategy Pattern][e5-f1] — Status: In Progress (P4, #1125)
+- [E5-F1: Latent Heat Strategy Pattern][e5-f1] — Status: Completed (P2, #1123)
   - Scope: `LatentHeatStrategy` ABC with constant, linear, and power-law
     implementations plus builder/factory integration.
 - [E5-F2: Non-Isothermal Mass Transfer Functions][e5-f2] — Status: Planning

--- a/adw-docs/dev-plans/epics/E5-non-isothermal-condensation.md
+++ b/adw-docs/dev-plans/epics/E5-non-isothermal-condensation.md
@@ -134,9 +134,8 @@ L -> 0 as T -> T_c. Used in engineering thermodynamics and EOS-based models.
   - Tests: `particula/gas/tests/latent_heat_strategies_test.py`
   - Test constant returns correct value, array broadcasting, type consistency
 
-- [x] **E5-F1-P2**: Add `LinearLatentHeat` and `PowerLawLatentHeat` strategies
+- [ ] **E5-F1-P2**: Add `LinearLatentHeat` and `PowerLawLatentHeat` strategies
   with tests
-  - Issue: #1123 | Status: Complete
   - `LinearLatentHeat(latent_heat_ref, slope, temperature_ref)`:
     `L(T) = L_ref - slope * (T - T_ref)`
   - `PowerLawLatentHeat(latent_heat_ref, critical_temperature, beta)`:
@@ -160,7 +159,6 @@ L -> 0 as T -> T_c. Used in engineering thermodynamics and EOS-based models.
   - Tests: build with valid params, missing-param errors, round-trip values
 
 - [ ] **E5-F1-P4**: Add latent heat factory and gas exports with tests
-  - Issue: #1125 | Status: In Progress
   - File: `particula/gas/latent_heat_factories.py`
   - `LatentHeatFactory` extends `StrategyFactoryABC` (from
     `particula/abc_factory.py`, 111 lines — same pattern as

--- a/adw-docs/dev-plans/features/E5-F1-latent-heat-strategy.md
+++ b/adw-docs/dev-plans/features/E5-F1-latent-heat-strategy.md
@@ -6,7 +6,7 @@
 **Owners**: @Gorkowski
 **Start Date**: 2026-03-01
 **Target Date**: TBD
-**Last Updated**: 2026-03-03
+**Last Updated**: 2026-03-02
 **Size**: Medium (4 phases)
 
 ## Summary
@@ -160,7 +160,7 @@ get_builders() -> {
   - Tests: build with valid params, missing-param errors, round-trip values
 
 - [ ] **E5-F1-P4**: Add latent heat factory and gas exports with tests
-  - Issue: #1125 | Size: S (~60 LOC) | Status: In Progress
+  - Issue: TBD | Size: S (~60 LOC) | Status: Not Started
   - File: `particula/gas/latent_heat_factories.py`
   - `LatentHeatFactory` extends `StrategyFactoryABC` (from
     `particula/abc_factory.py`, 111 lines -- same pattern as
@@ -227,4 +227,3 @@ get_builders() -> {
 |------|--------|--------|
 | 2026-03-01 | Initial feature document created from E5 epic | ADW |
 | 2026-03-02 | Completed E5-F1-P1 (ABC + constant strategy + tests) | ADW |
-| 2026-03-03 | Started E5-F1-P4 (latent heat factory + exports) | ADW |

--- a/particula/gas/latent_heat_factories.py
+++ b/particula/gas/latent_heat_factories.py
@@ -4,8 +4,6 @@ This module exposes :class:`LatentHeatFactory`, which builds constant,
 linear, and power-law latent heat strategies via their respective builders.
 """
 
-from typing import Union
-
 from particula.abc_factory import StrategyFactoryABC
 from particula.gas.latent_heat_builders import (
     ConstantLatentHeatBuilder,
@@ -14,23 +12,19 @@ from particula.gas.latent_heat_builders import (
 )
 from particula.gas.latent_heat_strategies import (
     ConstantLatentHeat,
-    LatentHeatStrategy,
     LinearLatentHeat,
     PowerLawLatentHeat,
 )
 
-LatentHeatBuilderType = Union[
-    ConstantLatentHeatBuilder,
-    LinearLatentHeatBuilder,
-    PowerLawLatentHeatBuilder,
-]
+LatentHeatBuilderType = (
+    ConstantLatentHeatBuilder
+    | LinearLatentHeatBuilder
+    | PowerLawLatentHeatBuilder
+)
 
-LatentHeatStrategyType = Union[
-    LatentHeatStrategy,
-    ConstantLatentHeat,
-    LinearLatentHeat,
-    PowerLawLatentHeat,
-]
+LatentHeatStrategyType = (
+    ConstantLatentHeat | LinearLatentHeat | PowerLawLatentHeat
+)
 
 
 class LatentHeatFactory(
@@ -58,8 +52,7 @@ class LatentHeatFactory(
         """Return latent heat builders keyed by strategy name.
 
         Returns:
-            dict[str, LatentHeatBuilderType]: Builder instances keyed by
-                strategy type.
+            Builder instances keyed by strategy type.
 
         Examples:
             >>> from particula.gas import LatentHeatFactory

--- a/particula/gas/tests/latent_heat_factories_test.py
+++ b/particula/gas/tests/latent_heat_factories_test.py
@@ -52,6 +52,8 @@ def test_factory_linear():
         parameters=parameters,
     )
     assert isinstance(strategy, LinearLatentHeat)
+    expected = 2.26e6 - 1200.0 * (300.0 - 298.15)
+    assert strategy.latent_heat(300.0) == pytest.approx(expected)
 
 
 def test_factory_power_law():
@@ -68,6 +70,8 @@ def test_factory_power_law():
         parameters=parameters,
     )
     assert isinstance(strategy, PowerLawLatentHeat)
+    expected = 2.26e6 * (1.0 - 300.0 / 647.096) ** 0.38
+    assert strategy.latent_heat(300.0) == pytest.approx(expected)
 
 
 def test_factory_invalid_type():


### PR DESCRIPTION
**Target Branch:** `main`

**Fixes #1125** | Workflow: `ad17bae7`

## Summary
Adds a latent-heat factory that mirrors the existing vapor-pressure pattern, wiring constant, linear, and power-law strategies into the gas namespace. Exposes all latent-heat strategies, builders, and the factory via `particula.gas` so downstream condensation work can configure latent-heat behavior consistently. Updates docs and dev-plan entries to reflect the new factory and exports.

## What Changed

### New Components
- `particula/gas/latent_heat_factories.py` – `LatentHeatFactory` extending `StrategyFactoryABC`, mapping strategy names to latent-heat builders.

### Modified Components
- `particula/gas/__init__.py` – Imports/exports latent-heat strategies, builders, and factory; updates `__all__` to include 8 new symbols.
- `adw-docs/dev-plans/features/E5-F1-latent-heat-strategy.md` – Marks P4 factory phase progress and notes exports.
- `adw-docs/dev-plans/epics/E5-non-isothermal-condensation.md` – Epic status text updated for latent-heat factory phase.
- `adw-docs/dev-plans/README.md`, `docs/index.md`, `readme.md` – Reflect latent-heat factory availability and gas-phase builder/factory pattern.

### Tests Added/Updated
- `particula/gas/tests/latent_heat_factories_test.py` – Factory mapping coverage (constant/linear/power-law), invalid type and missing-parameter errors, round-trip evaluation, and gas-namespace import smoke tests.

## How It Works
`LatentHeatFactory` inherits the shared `StrategyFactoryABC` pattern and returns the builder mapping used by `get_strategy()` to construct strategies:
```
LatentHeatFactory
    └── get_builders()
           ├── "constant"   → ConstantLatentHeatBuilder → ConstantLatentHeat
           ├── "linear"     → LinearLatentHeatBuilder   → LinearLatentHeat
           └── "power_law"  → PowerLawLatentHeatBuilder → PowerLawLatentHeat
```
The gas namespace now re-exports the strategies, builders, and factory so callers can use `from particula.gas import LatentHeatFactory` or `par.gas.LatentHeatFactory()` directly.

## Implementation Notes
- Mirrors the vapor-pressure factory pattern for typing, docstrings, and mapping semantics to keep API symmetry across gas property factories.
- `__all__` ordering follows existing grouping: strategies → builders → factory, placed after vapor-pressure exports and before gas property functions.
- Docs tweaked to mention latent-heat factory availability and gas builder/factory pattern.

## Testing
- `pytest particula/gas/tests/latent_heat_factories_test.py`
- Prior workflow run included full test suite (`pytest -Werror`) before ship phase.
