### PR TITLE
feat: E3-F7 - Add CPU latent-heat conservation baseline

### DIFF
--- a/.opencode/plans/features/E3-F7.json
+++ b/.opencode/plans/features/E3-F7.json
@@ -2,7 +2,7 @@
   "id": "E3-F7",
   "type": "feature",
   "title": "Add CPU integration-level latent-heat conservation baseline",
-  "status": "Draft",
+  "status": "Shipped",
   "priority": "P2",
   "size": "M",
   "owners": [
@@ -60,11 +60,11 @@
     {
       "id": "E3-F7-P3",
       "title": "Document Epic D CPU latent-heat baseline and validation guidance",
-      "status": "Not Started",
+      "status": "Shipped",
       "size": "XS",
       "issue_number": null,
       "start_date": null,
-      "completion_date": null,
+      "completion_date": "2026-07-11",
       "estimates": null,
       "actuals": null,
       "notes_ref": null,
@@ -72,5 +72,5 @@
     }
   ],
   "totals": null,
-  "lifecycle": "active"
+  "lifecycle": "completed"
 }

--- a/.opencode/plans/features/E3-F7.json
+++ b/.opencode/plans/features/E3-F7.json
@@ -11,7 +11,7 @@
   "start_date": "2026-07-08",
   "target_date": null,
   "completion_date": null,
-  "last_updated": "2026-07-08",
+  "last_updated": "2026-07-11",
   "dependencies": [],
   "section_files": {
     "architecture_design": ".opencode/plans/sections/features/E3-F7/architecture_design.md",
@@ -34,11 +34,11 @@
     {
       "id": "E3-F7-P1",
       "title": "Adapt particle-resolved latent-heat fixture as an integration test",
-      "status": "Not Started",
+      "status": "Shipped",
       "size": "S",
       "issue_number": null,
       "start_date": null,
-      "completion_date": null,
+      "completion_date": "2026-07-11",
       "estimates": null,
       "actuals": null,
       "notes_ref": null,

--- a/.opencode/plans/features/E3-F7.json
+++ b/.opencode/plans/features/E3-F7.json
@@ -47,11 +47,11 @@
     {
       "id": "E3-F7-P2",
       "title": "Assert CPU mass conservation and latent-heat energy bookkeeping",
-      "status": "Not Started",
+      "status": "Shipped",
       "size": "S",
       "issue_number": null,
       "start_date": null,
-      "completion_date": null,
+      "completion_date": "2026-07-11",
       "estimates": null,
       "actuals": null,
       "notes_ref": null,

--- a/.opencode/plans/sections/features/E3-F7/change_log.md
+++ b/.opencode/plans/sections/features/E3-F7/change_log.md
@@ -14,3 +14,13 @@
 - Expanded success criteria into measurable pass/fail checks, evidence metrics,
   and a definition of done centered on a deterministic single-species CPU
   baseline, conservation assertions, and CPU-only reference documentation.
+
+## 2026-07-11
+
+- Updated the plan sections to reflect shipped issue #1267 / E3-F7-P1 work.
+- Recorded that
+  `particula/integration_tests/condensation_latent_heat_conservation_test.py`
+  now provides the CPU-only integration baseline via public `particula` APIs,
+  a constant latent-heat strategy, and `MassCondensation.execute()`.
+- Noted that P1 shipped only lightweight execution/bookkeeping assertions and
+  did not change production code or user-facing documentation.

--- a/.opencode/plans/sections/features/E3-F7/documentation_updates.md
+++ b/.opencode/plans/sections/features/E3-F7/documentation_updates.md
@@ -3,7 +3,8 @@
 ## Current Slice Status
 
 - No documentation files changed in issue #1267 / E3-F7-P1.
-- This slice intentionally stayed limited to
+- No documentation files changed in issue #1268 / E3-F7-P2.
+- Both shipped slices intentionally stayed limited to
   `particula/integration_tests/condensation_latent_heat_conservation_test.py`.
 
 ## Deferred Updates

--- a/.opencode/plans/sections/features/E3-F7/documentation_updates.md
+++ b/.opencode/plans/sections/features/E3-F7/documentation_updates.md
@@ -4,28 +4,40 @@
 
 - No documentation files changed in issue #1267 / E3-F7-P1.
 - No documentation files changed in issue #1268 / E3-F7-P2.
-- Both shipped slices intentionally stayed limited to
-  `particula/integration_tests/condensation_latent_heat_conservation_test.py`.
+- Issue #1269 / E3-F7-P3 shipped the planned docs-only follow-up in:
+  - `docs/Features/Roadmap/data-oriented-gpu.md`
+  - `docs/Features/condensation_strategy_system.md`
 
-## Deferred Updates
+## Implemented Updates
 
 - `docs/Features/Roadmap/data-oriented-gpu.md`
-  - Mark or describe E3-F7 as the CPU integration-level latent-heat baseline
+  - Documents E3-F7 as the current CPU integration-level latent-heat baseline
     for future Epic D GPU parity work.
-  - State explicitly that the feature does not claim GPU latent-heat parity.
+  - Points readers to
+    `particula/integration_tests/condensation_latent_heat_conservation_test.py`
+    as the executable reference test.
+  - Summarizes the baseline invariants conservatively: finite nonzero
+    condensation transfer, particle water gain, gas water loss, total water
+    conservation, and final-step `last_latent_heat_energy` agreement with the
+    constant-latent-heat bookkeeping path.
+  - Keeps wording future-facing and explicitly avoids any claim of shipped GPU
+    latent-heat parity or temperature-feedback runtime support.
 
 - `docs/Features/condensation_strategy_system.md`
-  - Add a short note that latent-heat condensation now has an integration-level
-    CPU baseline under `particula/integration_tests/`.
-  - Summarize the later-phase invariants: particle/gas mass conservation and
-    latent-heat energy bookkeeping.
+  - Adds the same executable CPU baseline reference in the
+    `CondensationLatentHeat` section.
+  - Keeps the public support boundary explicit: CPU-only and
+    diagnostic/reference only.
+  - Includes the existing E3-F6 latent-heat example cross-link in related
+    documentation alongside the integration baseline path.
 
-## Optional Cross-References
+## Validation Notes
 
-- Link to the E3-F6 runnable CPU latent-heat example if it exists at
-  implementation time.
-- Mention the focused test command for maintainers who need to reproduce the
-  baseline quickly.
+- The shipped docs changes stay limited to the two planned documentation files.
+- The executable baseline remains
+  `particula/integration_tests/condensation_latent_heat_conservation_test.py`.
+- Feature-page wording continues to avoid implying completed GPU latent-heat
+  parity.
 
 ## Wording Guardrails
 

--- a/.opencode/plans/sections/features/E3-F7/documentation_updates.md
+++ b/.opencode/plans/sections/features/E3-F7/documentation_updates.md
@@ -1,17 +1,23 @@
 # Documentation Updates
 
-## Required Updates
+## Current Slice Status
+
+- No documentation files changed in issue #1267 / E3-F7-P1.
+- This slice intentionally stayed limited to
+  `particula/integration_tests/condensation_latent_heat_conservation_test.py`.
+
+## Deferred Updates
 
 - `docs/Features/Roadmap/data-oriented-gpu.md`
-- Mark or describe E3-F7 as the CPU integration-level latent-heat
-    conservation baseline for future Epic D GPU parity work.
+  - Mark or describe E3-F7 as the CPU integration-level latent-heat baseline
+    for future Epic D GPU parity work.
   - State explicitly that the feature does not claim GPU latent-heat parity.
 
 - `docs/Features/condensation_strategy_system.md`
   - Add a short note that latent-heat condensation now has an integration-level
-    CPU conservation baseline under `particula/integration_tests/`.
-  - Summarize the invariants: particle/gas mass conservation and latent-heat
-    energy bookkeeping.
+    CPU baseline under `particula/integration_tests/`.
+  - Summarize the later-phase invariants: particle/gas mass conservation and
+    latent-heat energy bookkeeping.
 
 ## Optional Cross-References
 

--- a/.opencode/plans/sections/features/E3-F7/implementation_tasks.md
+++ b/.opencode/plans/sections/features/E3-F7/implementation_tasks.md
@@ -2,17 +2,21 @@
 
 ## E3-F7-P1: Fixture Adaptation
 
-- Review `particula/integration_tests/condensation_particle_resolved_test.py` and
-  mirror its deterministic setup style.
-- Create `particula/integration_tests/condensation_latent_heat_conservation_test.py`.
-- Build a supersaturated CPU water condensation scenario with partitioning gas
-  and particle-resolved water mass, keeping any test-local fixture builders in
-  the same module as private helpers such as `_build_test_aerosol()`.
-- Instantiate `CondensationLatentHeat` through public imports with a
-  `ConstantLatentHeat` strategy produced by `par.gas.LatentHeatFactory()`.
-- Execute a short fixed loop using `MassCondensation.execute()` and keep the new
-  setup plus first assertion block close enough to review in one pass rather
-  than splitting core fixture logic across multiple support files.
+- [x] Reviewed
+  `particula/integration_tests/condensation_particle_resolved_test.py` and
+  mirrored its deterministic setup style.
+- [x] Created
+  `particula/integration_tests/condensation_latent_heat_conservation_test.py`.
+- [x] Built a supersaturated CPU water condensation scenario with partitioning
+  gas and particle-resolved water mass, keeping test-local fixture builders in
+  the same module as private helpers.
+- [x] Instantiated `CondensationLatentHeat` through public imports with a
+  constant latent-heat strategy produced by `par.gas.LatentHeatFactory()`.
+- [x] Executed a short fixed loop using `MassCondensation.execute()`.
+- [x] Kept the shipped P1 assertions intentionally lightweight: supersaturation
+  precondition, gas decrease, particle mass increase, and finite
+  `last_latent_heat_energy`.
+- [x] Kept the diff scoped to the new integration test module only.
 
 ## E3-F7-P2: Conservation and Energy Assertions
 

--- a/.opencode/plans/sections/features/E3-F7/implementation_tasks.md
+++ b/.opencode/plans/sections/features/E3-F7/implementation_tasks.md
@@ -20,20 +20,24 @@
 
 ## E3-F7-P2: Conservation and Energy Assertions
 
-- Capture initial particle water inventory and gas water concentration.
-- Capture final particle water inventory and gas water concentration.
-- Assert particle water increased and gas water decreased.
-- Assert total water inventory is conserved within a stable deterministic
-  tolerance, using the existing integration test's tolerance as the starting
-  point.
-- Assert `last_latent_heat_energy` is finite and positive.
-- Compute expected latent heat from transferred mass and the exact constant
-  latent-heat value passed into the factory or strategy setup, then compare with
-  `last_latent_heat_energy` using tight but stable tolerances.
-- Run the focused integration test and then the default integration-test command
-  used by the repository.
-- Keep the assertion edit to one integration test module with a small number of
-  named assertions or helper functions, not a new shared testing utility.
+- [x] Captured initial/final particle water inventory and initial/final gas water
+  concentration on the shipped single-species CPU fixture.
+- [x] Added explicit `LATENT_HEAT_WATER`, `CONSERVATION_RTOL`, and
+  `CONSERVATION_ATOL` module constants for deterministic bookkeeping checks.
+- [x] Added a private `_particle_water_inventory(...)` helper local to
+  `particula/integration_tests/condensation_latent_heat_conservation_test.py`.
+- [x] Split the execution flow so the test records the penultimate state before
+  the fifth/final `MassCondensation.execute()` call.
+- [x] Asserted whole-run directional transfer: particle water increases and gas
+  water decreases.
+- [x] Asserted whole-run total water inventory conservation with explicit tight
+  deterministic tolerances.
+- [x] Asserted `last_latent_heat_energy` is finite and positive.
+- [x] Asserted final-step particle gain matches final-step gas loss and that the
+  recorded latent-heat energy equals final-step transferred mass times the exact
+  latent-heat constant used by the fixture.
+- [x] Kept the implementation scoped to the existing integration test module
+  only, with no production-code or documentation changes in issue #1268.
 
 ## E3-F7-P3: Documentation
 

--- a/.opencode/plans/sections/features/E3-F7/open_questions.md
+++ b/.opencode/plans/sections/features/E3-F7/open_questions.md
@@ -13,6 +13,7 @@ Status: reviewed and answered on 2026-07-08.
 - Use the existing integration tolerance of `1e-9` as the initial water
   inventory tolerance, then tighten with `np.testing.assert_allclose` only after
   fixture tuning proves stable energy behavior.
-- Cross-link to the E3-F6 example when it exists. Until then, record the link as
-  a follow-up in E3-F7 documentation updates rather than blocking the baseline
-  test.
+- Cross-link to the E3-F6 example when it exists. This is now resolved in the
+  shipped P3 docs update: `docs/Features/condensation_strategy_system.md`
+  keeps the existing latent-heat example link and also points readers to the
+  executable CPU integration baseline.

--- a/.opencode/plans/sections/features/E3-F7/overview.md
+++ b/.opencode/plans/sections/features/E3-F7/overview.md
@@ -14,12 +14,16 @@ assertions for follow-up work.
 ## Value Proposition
 
 E3-F7 now has shipped P1 and P2 coverage in
-`particula/integration_tests/condensation_latent_heat_conservation_test.py`.
-The implemented slice still uses only public `particula` APIs, a constant
-latent-heat strategy, and `MassCondensation.execute()`, but now also proves the
-CPU reference fixture conserves whole-run water inventory and that
-`last_latent_heat_energy` matches the final-step transferred water mass times
-the explicit latent-heat constant.
+`particula/integration_tests/condensation_latent_heat_conservation_test.py`,
+and shipped P3 documentation updates in
+`docs/Features/Roadmap/data-oriented-gpu.md` and
+`docs/Features/condensation_strategy_system.md`. The implemented slice still
+uses only public `particula` APIs, a constant latent-heat strategy, and
+`MassCondensation.execute()`, but now also proves the CPU reference fixture
+conserves whole-run water inventory, that `last_latent_heat_energy` matches
+the final-step transferred water mass times the explicit latent-heat constant,
+and that the roadmap/feature docs point future Epic D work to this CPU-only
+diagnostic baseline without implying shipped GPU parity.
 
 This leaves the feature with a stronger executable CPU reference baseline for
 future GPU parity work while preserving the constraint that no GPU latent-heat

--- a/.opencode/plans/sections/features/E3-F7/overview.md
+++ b/.opencode/plans/sections/features/E3-F7/overview.md
@@ -3,34 +3,37 @@
 ## Problem Statement
 
 Epic C closes with CPU examples and GPU hardening work, but future Epic D GPU
-latent-heat parity needs a deterministic CPU integration-level reference before
-any GPU parity claim can be evaluated. Existing latent-heat checks are strong at
-the unit level, and `condensation_particle_resolved_test.py` already proves the
-particle-resolved condensation integration style, but there is no default
-integration test that combines particle/gas mass conservation with latent-heat
-energy bookkeeping through the public CPU runnable path.
+latent-heat parity still needs a deterministic CPU integration-level reference
+before any GPU parity claim can be evaluated. Existing latent-heat checks are
+strong at the unit level, and `condensation_particle_resolved_test.py` already
+proves the particle-resolved condensation integration style. P1 now fills the
+remaining gap with a default integration baseline for the public CPU
+latent-heat runnable path, while leaving full conservation and energy-closure
+assertions for follow-up work.
 
 ## Value Proposition
 
-E3-F7 adds a CPU-only baseline that future GPU work can compare against without
-changing production GPU behavior. The baseline should be fast enough for default
-integration tests, deterministic, and explicit about two invariants:
+E3-F7 now has a shipped P1 baseline in
+`particula/integration_tests/condensation_latent_heat_conservation_test.py`.
+The implemented slice uses only public `particula` APIs, a constant latent-heat
+strategy, and `MassCondensation.execute()` to prove that a deterministic,
+supersaturated single-species water fixture transfers mass through the CPU
+runnable path and leaves `last_latent_heat_energy` finite.
 
-- water inventory is conserved between particles and gas; and
-- `CondensationLatentHeat.last_latent_heat_energy` matches the mass transfer
-  times a constant latent heat strategy.
-
-This gives Epic D a stable acceptance target while preserving the constraint
-that no GPU latent-heat production parity is claimed in this feature.
+This gives later phases a stable executable fixture for strict conservation and
+energy-equality assertions while preserving the constraint that no GPU
+latent-heat production parity is claimed in this feature.
 
 ## User Stories
 
 - As a GPU implementer, I want a CPU latent-heat integration baseline so that I
   can compare future GPU latent-heat behavior against a reviewed reference.
-- As a maintainer, I want the baseline to run in the default integration suite so
-  that conservation regressions are caught before Epic D work begins.
-- As a documentation reader, I want the roadmap to identify this as CPU-only so
-  that I do not mistake it for completed GPU parity.
+- As a maintainer, I want the baseline to run in the default integration suite
+  so that public CPU latent-heat runnable regressions are caught before Epic D
+  work begins.
+- As a follow-up implementer, I want P1 to stay intentionally lightweight so P2
+  can add strict conservation and energy-equality checks on top of a reviewed
+  fixture.
 
 ## Parent Epic Context
 

--- a/.opencode/plans/sections/features/E3-F7/overview.md
+++ b/.opencode/plans/sections/features/E3-F7/overview.md
@@ -13,16 +13,17 @@ assertions for follow-up work.
 
 ## Value Proposition
 
-E3-F7 now has a shipped P1 baseline in
+E3-F7 now has shipped P1 and P2 coverage in
 `particula/integration_tests/condensation_latent_heat_conservation_test.py`.
-The implemented slice uses only public `particula` APIs, a constant latent-heat
-strategy, and `MassCondensation.execute()` to prove that a deterministic,
-supersaturated single-species water fixture transfers mass through the CPU
-runnable path and leaves `last_latent_heat_energy` finite.
+The implemented slice still uses only public `particula` APIs, a constant
+latent-heat strategy, and `MassCondensation.execute()`, but now also proves the
+CPU reference fixture conserves whole-run water inventory and that
+`last_latent_heat_energy` matches the final-step transferred water mass times
+the explicit latent-heat constant.
 
-This gives later phases a stable executable fixture for strict conservation and
-energy-equality assertions while preserving the constraint that no GPU
-latent-heat production parity is claimed in this feature.
+This leaves the feature with a stronger executable CPU reference baseline for
+future GPU parity work while preserving the constraint that no GPU latent-heat
+production parity is claimed in this feature.
 
 ## User Stories
 
@@ -31,9 +32,9 @@ latent-heat production parity is claimed in this feature.
 - As a maintainer, I want the baseline to run in the default integration suite
   so that public CPU latent-heat runnable regressions are caught before Epic D
   work begins.
-- As a follow-up implementer, I want P1 to stay intentionally lightweight so P2
-  can add strict conservation and energy-equality checks on top of a reviewed
-  fixture.
+- As a follow-up implementer, I want the reviewed fixture to support strict
+  conservation and energy-equality checks without changing production code or
+  widening scope beyond the CPU integration test.
 
 ## Parent Epic Context
 

--- a/.opencode/plans/sections/features/E3-F7/phase_details.md
+++ b/.opencode/plans/sections/features/E3-F7/phase_details.md
@@ -39,8 +39,8 @@
   - Scope guardrail confirmed: no production code or user-facing docs changed in
     this slice.
 
-- [ ] **E3-F7-P3:** Document Epic D CPU latent-heat baseline and validation guidance
-  - Issue: TBD | Size: XS | Status: Not Started
+- [x] **E3-F7-P3:** Document Epic D CPU latent-heat baseline and validation guidance
+  - Issue: #1269 | Size: XS | Status: Implemented
   - Depends on: E3-F7-P2 proving the executable baseline and, if E3-F6 has
     landed, using that final example path for documentation cross-links without
     blocking the CPU integration baseline on docs-example timing.
@@ -48,7 +48,16 @@
     for future Epic D GPU parity work.
   - Files: `docs/Features/Roadmap/data-oriented-gpu.md`,
     `docs/Features/condensation_strategy_system.md`.
-  - Tests: Documentation changes are reviewed for accurate CPU-only wording and
-    the default integration test remains the executable validation artifact.
-  - Deliverable: Update developer-facing roadmap or feature docs so the final
-    phase leaves explicit CPU-reference guidance for later GPU parity work.
+  - Implementation: Updated `docs/Features/Roadmap/data-oriented-gpu.md` and
+    `docs/Features/condensation_strategy_system.md` so both pages point readers
+    to `particula/integration_tests/condensation_latent_heat_conservation_test.py`
+    as the shipped CPU latent-heat baseline for future Epic D parity work,
+    summarize the conserved particle/gas water bookkeeping plus
+    `last_latent_heat_energy` agreement, and keep wording CPU-only and
+    diagnostic/reference only.
+  - Tests: Documentation wording is cross-checked against the executable CPU
+    baseline and the focused docs regression
+    `particula/tests/condensation_latent_heat_docs_test.py`.
+  - Deliverable: Shipped roadmap and condensation feature-page guidance that
+    identifies the executable CPU baseline without implying completed GPU
+    latent-heat parity.

--- a/.opencode/plans/sections/features/E3-F7/phase_details.md
+++ b/.opencode/plans/sections/features/E3-F7/phase_details.md
@@ -1,20 +1,23 @@
 # Phase Details
 
-- [ ] **E3-F7-P1:** Adapt particle-resolved latent-heat fixture as an integration test
-  - Issue: TBD | Size: S | Status: Not Started
+- [x] **E3-F7-P1:** Adapt particle-resolved latent-heat fixture as an integration test
+  - Issue: #1267 | Size: S | Status: Implemented
   - Depends on: Existing CPU latent-heat APIs staying stable and, when
     available, E3-F6 providing the finalized example path for later cross-links;
     the integration fixture itself does not need to wait for E3-F6 to merge.
   - Goal: Create a minimal deterministic single-species CPU integration fixture
     based on the existing particle-resolved condensation style, but using
     `CondensationLatentHeat`.
-  - Files: `particula/integration_tests/condensation_latent_heat_conservation_test.py`,
-    optionally shared local helpers within the same test module.
-  - Tests: New integration test constructs an aerosol, partitioning gas species,
-    constant latent-heat strategy, and `MassCondensation` runnable through CPU
-    public APIs.
-  - Extension: Add a small multi-species variant only if it remains fast,
-    deterministic, and stable under the default integration suite.
+  - Files: `particula/integration_tests/condensation_latent_heat_conservation_test.py`.
+  - Implementation: Added a CPU-only baseline that builds a supersaturated
+    single-species water aerosol through public `particula as par` APIs,
+    configures a constant latent-heat strategy, and executes
+    `MassCondensation.execute()` over a short fixed loop.
+  - Assertions shipped in P1: supersaturation precondition, gas concentration
+    decreases, particle mass concentration increases, and
+    `last_latent_heat_energy` remains finite.
+  - Scope guardrail confirmed: no production code or user-facing docs changed in
+    this slice.
 
 - [ ] **E3-F7-P2:** Assert CPU mass conservation and latent-heat energy bookkeeping
   - Issue: TBD | Size: S | Status: Not Started

--- a/.opencode/plans/sections/features/E3-F7/phase_details.md
+++ b/.opencode/plans/sections/features/E3-F7/phase_details.md
@@ -19,18 +19,25 @@
   - Scope guardrail confirmed: no production code or user-facing docs changed in
     this slice.
 
-- [ ] **E3-F7-P2:** Assert CPU mass conservation and latent-heat energy bookkeeping
-  - Issue: TBD | Size: S | Status: Not Started
+- [x] **E3-F7-P2:** Assert CPU mass conservation and latent-heat energy bookkeeping
+  - Issue: #1268 | Size: S | Status: Implemented
   - Depends on: E3-F7-P1 establishing the deterministic fixture so conservation
     and latent-heat assertions target a stable baseline instead of evolving setup
     code.
   - Goal: Add robust assertions proving particle/gas water inventory conservation
     and latent-heat energy consistency for the CPU reference path.
-  - Files: `particula/integration_tests/condensation_latent_heat_conservation_test.py`,
-    with minimal updates to condensation helpers only if required for clarity.
-  - Tests: Assert particle water increases, gas water decreases, total water mass
-    is conserved within stable tolerance, `last_latent_heat_energy` is finite and
-    positive, and energy equals transferred mass times constant latent heat.
+  - Files: `particula/integration_tests/condensation_latent_heat_conservation_test.py` only.
+  - Implementation: Added explicit latent-heat and conservation tolerance
+    constants, a private particle-water inventory helper, initial/pre-final/final
+    water bookkeeping captures, and stronger integration assertions over the
+    existing five-step CPU execution path.
+  - Assertions shipped in P2: initial/final particle water inventory,
+    initial/final gas water inventory, whole-run total water conservation,
+    final-step particle gain versus gas loss, finite positive
+    `last_latent_heat_energy`, and final-step latent-heat energy equality using
+    the exact fixture constant.
+  - Scope guardrail confirmed: no production code or user-facing docs changed in
+    this slice.
 
 - [ ] **E3-F7-P3:** Document Epic D CPU latent-heat baseline and validation guidance
   - Issue: TBD | Size: XS | Status: Not Started

--- a/.opencode/plans/sections/features/E3-F7/success_criteria.md
+++ b/.opencode/plans/sections/features/E3-F7/success_criteria.md
@@ -26,6 +26,7 @@ including at minimum:
 
 ```bash
 pytest particula/integration_tests/condensation_latent_heat_conservation_test.py -q
+pytest particula/tests/condensation_latent_heat_docs_test.py -q
 pytest particula/integration_tests -q
 ```
 

--- a/.opencode/plans/sections/features/E3-F7/testing_strategy.md
+++ b/.opencode/plans/sections/features/E3-F7/testing_strategy.md
@@ -19,8 +19,12 @@
   pre-final, and final particle/gas water bookkeeping; asserts whole-run water
   conservation; and checks that final-step particle gain, gas loss, and
   `last_latent_heat_energy` all close against the explicit constant latent heat.
-- **P3:** Keep documentation validation lightweight; verify the documented test
-  path and CPU-only constraints match the implemented baseline.
+- **P3 (implemented):** Documentation validation stayed lightweight and focused
+  on the shipped wording contract. The updated roadmap and condensation feature
+  docs now reference
+  `particula/integration_tests/condensation_latent_heat_conservation_test.py`,
+  keep the baseline CPU-only/diagnostic-only, and avoid any claim of completed
+  GPU latent-heat parity.
 
 ## Current Assertions
 
@@ -45,5 +49,6 @@ not require `slow`, `performance`, GPU, CUDA, or Warp markers.
 
 ```bash
 pytest particula/integration_tests/condensation_latent_heat_conservation_test.py -q -Werror
+pytest particula/tests/condensation_latent_heat_docs_test.py -q -Werror
 pytest particula/integration_tests -q
 ```

--- a/.opencode/plans/sections/features/E3-F7/testing_strategy.md
+++ b/.opencode/plans/sections/features/E3-F7/testing_strategy.md
@@ -9,22 +9,30 @@
 
 ## Per-Phase Testing Approach
 
-- **P1:** Add the minimal deterministic single-species integration fixture and a
-  smoke-level assertion that the CPU latent-heat runnable executes
-  deterministically through `MassCondensation`. Add a small multi-species
-  extension only if it remains fast and stable.
+- **P1 (implemented):** The new module ships a deterministic single-species
+  CPU integration fixture with two focused tests: one verifies the initial
+  state is supersaturated, and one runs a short fixed
+  `MassCondensation.execute()` loop and checks that gas decreases, particle
+  mass increases, and latent-heat bookkeeping stays finite. No multi-species
+  extension was added in this slice.
 - **P2:** Add full conservation and energy bookkeeping assertions in the same
   integration test file. These assertions are the core acceptance gate.
 - **P3:** Keep documentation validation lightweight; verify the documented test
   path and CPU-only constraints match the implemented baseline.
 
-## Required Assertions
+## Current Assertions
 
 - Particle water/speciated mass increases after condensation.
 - Partitioning gas water concentration decreases.
+- Initial supersaturation is asserted so the baseline cannot silently become a
+  no-op fixture.
+- `CondensationLatentHeat.last_latent_heat_energy` is finite.
+
+## Deferred Assertions for P2
+
 - Total water inventory across particles and gas is conserved within a stable
   deterministic tolerance.
-- `CondensationLatentHeat.last_latent_heat_energy` is finite and positive.
+- `CondensationLatentHeat.last_latent_heat_energy` is positive.
 - Expected energy from transferred mass times constant latent heat matches
   `last_latent_heat_energy`.
 

--- a/.opencode/plans/sections/features/E3-F7/testing_strategy.md
+++ b/.opencode/plans/sections/features/E3-F7/testing_strategy.md
@@ -15,26 +15,25 @@
   `MassCondensation.execute()` loop and checks that gas decreases, particle
   mass increases, and latent-heat bookkeeping stays finite. No multi-species
   extension was added in this slice.
-- **P2:** Add full conservation and energy bookkeeping assertions in the same
-  integration test file. These assertions are the core acceptance gate.
+- **P2 (implemented):** The same integration test now captures initial,
+  pre-final, and final particle/gas water bookkeeping; asserts whole-run water
+  conservation; and checks that final-step particle gain, gas loss, and
+  `last_latent_heat_energy` all close against the explicit constant latent heat.
 - **P3:** Keep documentation validation lightweight; verify the documented test
   path and CPU-only constraints match the implemented baseline.
 
 ## Current Assertions
 
-- Particle water/speciated mass increases after condensation.
+- Particle water inventory increases after condensation.
 - Partitioning gas water concentration decreases.
 - Initial supersaturation is asserted so the baseline cannot silently become a
   no-op fixture.
-- `CondensationLatentHeat.last_latent_heat_energy` is finite.
-
-## Deferred Assertions for P2
-
-- Total water inventory across particles and gas is conserved within a stable
-  deterministic tolerance.
-- `CondensationLatentHeat.last_latent_heat_energy` is positive.
-- Expected energy from transferred mass times constant latent heat matches
-  `last_latent_heat_energy`.
+- Total water inventory across particles and gas is conserved within
+  `CONSERVATION_RTOL = 1e-12` and `CONSERVATION_ATOL = 1e-18`.
+- `CondensationLatentHeat.last_latent_heat_energy` is finite and positive.
+- Final-step particle water gain matches final-step gas water loss.
+- Expected final-step energy from transferred mass times
+  `LATENT_HEAT_WATER = 2.26e6` matches `last_latent_heat_energy`.
 
 ## Coverage Impact
 
@@ -45,6 +44,6 @@ not require `slow`, `performance`, GPU, CUDA, or Warp markers.
 ## Suggested Validation Commands
 
 ```bash
-pytest particula/integration_tests/condensation_latent_heat_conservation_test.py -q
+pytest particula/integration_tests/condensation_latent_heat_conservation_test.py -q -Werror
 pytest particula/integration_tests -q
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,7 +88,7 @@ def function(
 
 **Framework:** pytest  
 **Coverage:** pytest-cov  
-**Minimum tests:** 500 (current: 711)  
+**Minimum tests:** 500 (current: 713)  
 **Test pattern:** `*_test.py`
 
 **Registered markers:** `slow`, `performance`, `benchmark`, `warp`, `cuda`,
@@ -525,6 +525,6 @@ adw workflow list         # List available workflows
 
 ---
 
-**Last Updated:** 2026-07-05  
+**Last Updated:** 2026-07-11  
 **For questions about ADW:** See `.opencode/guides/README.md`  
 **For questions about particula:** See main `readme.md`

--- a/docs/Examples/Dynamics/index.md
+++ b/docs/Examples/Dynamics/index.md
@@ -7,7 +7,8 @@ including condensation, coagulation, and special customizations.
 ## Condensation
 
 These examples demonstrate bin-based and fully resolved approaches to
-modeling condensation, plus a CPU-only latent-heat bookkeeping walkthrough.
+modeling condensation, plus a CPU-only latent-heat diagnostic/reference
+walkthrough.
 
 - [Condensation 1: Bins](Condensation/Condensation_1_Bin.ipynb)
 - [Condensation 2: Masses Binned](Condensation/Condensation_2_MassBin.ipynb)
@@ -16,7 +17,8 @@ modeling condensation, plus a CPU-only latent-heat bookkeeping walkthrough.
   – Published CPU-only latent-heat bookkeeping walkthrough using
   `MassCondensation` with public factory/builder APIs. The reported
   energy density is diagnostic only and does not feed back into
-  temperature.
+  temperature. The executable CPU integration baseline remains
+  `particula/integration_tests/condensation_latent_heat_conservation_test.py`.
 - [Staggered Condensation](Condensation/Staggered_Condensation_Example.ipynb) – Demonstrates staggered ODE stepping for improved stability and mass conservation.
 
 ## Coagulation

--- a/docs/Features/Roadmap/data-oriented-gpu.md
+++ b/docs/Features/Roadmap/data-oriented-gpu.md
@@ -696,9 +696,9 @@ Shipped scope (tracked in plan E1):
   parity (fixed-shape state, explicit environment inputs, no hidden CPU↔GPU
   movement).
 
-Two follow-ups were deferred out of E1 (a runnable latent-heat example and
-an integration-level conservation case); they are scheduled as features 8
-and 9 in
+Two follow-ups were deferred out of E1: the runnable latent-heat example
+(E3-F6) and the integration-level conservation case (E3-F7). They are
+scheduled as features 8 and 9 in
 [Epic C](#epic-c-gpu-kernel-correctness-and-low-level-api-hardening).
 
 **Exit bar (met):** Latent-heat condensation is a documented, builder/factory
@@ -930,22 +930,21 @@ Planned features:
    vapor pressures recomputed on the GPU each timestep for parcel,
    expansion, and latent-heat workflows; today `vapor_pressure` is set once
    at transfer time and defaults to zeros.
-2. Warp-backed latent-heat condensation kernel matching CPU
-   `CondensationLatentHeat`, including latent-heat-corrected mass transfer
-   and per-step latent heat energy bookkeeping (see the
-   [condensation equations](../../Theory/Technical/Dynamics/Condensation_Equations.md#condensation-with-latent-heat)),
-   with per-box temperature feedback through the
-   [EnvironmentData Container](#environmentdata-container). E3-F7 provides
-   the current CPU integration-level latent-heat baseline for this future
-   Epic D work through the executable reference test
+2. Warp-backed latent-heat condensation kernel matching the shipped CPU
+   `CondensationLatentHeat` bookkeeping path, including latent-heat-
+   corrected mass transfer and per-step latent heat energy bookkeeping
+   (see the [condensation
+   equations](../../Theory/Technical/Dynamics/Condensation_Equations.md#condensation-with-latent-heat)).
+   E3-F7 provides the current executable CPU integration baseline for this
+   future Epic D work through
    `particula/integration_tests/condensation_latent_heat_conservation_test.py`.
    That CPU-only diagnostic/reference baseline verifies only a finite
    nonzero condensation transfer, particle water gain, gas water loss,
    total water conservation, and final-step
    `last_latent_heat_energy` agreement with the constant-latent-heat
-   bookkeeping path. It is baseline evidence for future Epic D GPU parity
-   work only; it does not claim shipped GPU latent-heat parity or
-   temperature-feedback runtime support.
+   bookkeeping path. Temperature-feedback runtime support and GPU
+   latent-heat parity remain future Epic D goals rather than shipped
+   behavior.
 3. Fixed-count sub-stepping integration: build GPU condensation on the
    `fixed_count_substeps_4` recommendation from the
    [condensation stiffness study](condensation-stiffness-study.md), keeping

--- a/docs/Features/Roadmap/data-oriented-gpu.md
+++ b/docs/Features/Roadmap/data-oriented-gpu.md
@@ -935,7 +935,15 @@ Planned features:
    and per-step latent heat energy bookkeeping (see the
    [condensation equations](../../Theory/Technical/Dynamics/Condensation_Equations.md#condensation-with-latent-heat)),
    with per-box temperature feedback through the
-   [EnvironmentData Container](#environmentdata-container).
+   [EnvironmentData Container](#environmentdata-container). The current
+   executable reference for this work is the CPU integration baseline in
+   `particula/integration_tests/condensation_latent_heat_conservation_test.py`:
+   it verifies particle water increases, gas water decreases, total water
+   inventory is conserved, and
+   `last_latent_heat_energy` matches the constant-latent-heat bookkeeping
+   path on the final CPU step. This is baseline evidence for future Epic D
+   GPU parity work, not evidence that GPU latent-heat parity is already
+   implemented.
 3. Fixed-count sub-stepping integration: build GPU condensation on the
    `fixed_count_substeps_4` recommendation from the
    [condensation stiffness study](condensation-stiffness-study.md), keeping

--- a/docs/Features/Roadmap/data-oriented-gpu.md
+++ b/docs/Features/Roadmap/data-oriented-gpu.md
@@ -935,15 +935,17 @@ Planned features:
    and per-step latent heat energy bookkeeping (see the
    [condensation equations](../../Theory/Technical/Dynamics/Condensation_Equations.md#condensation-with-latent-heat)),
    with per-box temperature feedback through the
-   [EnvironmentData Container](#environmentdata-container). The current
-   executable reference for this work is the CPU integration baseline in
-   `particula/integration_tests/condensation_latent_heat_conservation_test.py`:
-   it verifies particle water increases, gas water decreases, total water
-   inventory is conserved, and
-   `last_latent_heat_energy` matches the constant-latent-heat bookkeeping
-   path on the final CPU step. This is baseline evidence for future Epic D
-   GPU parity work, not evidence that GPU latent-heat parity is already
-   implemented.
+   [EnvironmentData Container](#environmentdata-container). E3-F7 provides
+   the current CPU integration-level latent-heat baseline for this future
+   Epic D work through the executable reference test
+   `particula/integration_tests/condensation_latent_heat_conservation_test.py`.
+   That CPU-only diagnostic/reference baseline verifies only a finite
+   nonzero condensation transfer, particle water gain, gas water loss,
+   total water conservation, and final-step
+   `last_latent_heat_energy` agreement with the constant-latent-heat
+   bookkeeping path. It is baseline evidence for future Epic D GPU parity
+   work only; it does not claim shipped GPU latent-heat parity or
+   temperature-feedback runtime support.
 3. Fixed-count sub-stepping integration: build GPU condensation on the
    `fixed_count_substeps_4` recommendation from the
    [condensation stiffness study](condensation-stiffness-study.md), keeping

--- a/docs/Features/condensation_strategy_system.md
+++ b/docs/Features/condensation_strategy_system.md
@@ -192,14 +192,14 @@ that diagnostic aligns with the mass-concentration contract and should be
 reported as an energy density.
 
 For the current shipped support boundary, E3-F7 is the executable CPU
-integration-level latent-heat baseline for future Epic D GPU parity work:
+integration baseline for future Epic D GPU parity work:
 `particula/integration_tests/condensation_latent_heat_conservation_test.py`.
 It verifies only a finite nonzero condensation transfer, particle water
 gain, gas water loss, total water conservation, and final-step
 `last_latent_heat_energy` agreement with the constant-latent-heat
 bookkeeping path. This baseline is CPU-only and diagnostic/reference only;
-it does not claim shipped GPU latent-heat parity or temperature-feedback
-runtime support.
+temperature-feedback runtime support and GPU latent-heat parity remain
+future work.
 
 ### CondensationIsothermalStaggered (two-pass Gauss-Seidel)
 
@@ -636,7 +636,7 @@ aerosol, gas = selective.step(
 
 - **Dynamics overview**: [Wall loss strategy system](./wall_loss_strategy_system.md)
 - **Examples**: [docs/Examples/Simulations/index.md](../Examples/Simulations/index.md)
-- **Latent-heat example**: [CPU latent-heat condensation bookkeeping](../Examples/Dynamics/Condensation/Condensation_Latent_Heat.ipynb)
+- **Latent-heat example (E3-F6)**: [CPU latent-heat condensation bookkeeping](../Examples/Dynamics/Condensation/Condensation_Latent_Heat.ipynb)
 - **CPU integration baseline**: `particula/integration_tests/condensation_latent_heat_conservation_test.py`
 - **Theory**: [docs/Theory/index.md](../Theory/index.md)
 

--- a/docs/Features/condensation_strategy_system.md
+++ b/docs/Features/condensation_strategy_system.md
@@ -191,15 +191,15 @@ step mass-transfer quantity. For the current single-box public example path,
 that diagnostic aligns with the mass-concentration contract and should be
 reported as an energy density.
 
-For the current shipped support boundary, the executable baseline is the
-CPU integration test
+For the current shipped support boundary, E3-F7 is the executable CPU
+integration-level latent-heat baseline for future Epic D GPU parity work:
 `particula/integration_tests/condensation_latent_heat_conservation_test.py`.
-It verifies a finite nonzero condensation transfer, particle water gain,
-gas water loss, total water conservation, and final-step
+It verifies only a finite nonzero condensation transfer, particle water
+gain, gas water loss, total water conservation, and final-step
 `last_latent_heat_energy` agreement with the constant-latent-heat
-bookkeeping path. This baseline is CPU-only and diagnostic only; it does not
-claim completed GPU latent-heat parity or temperature-feedback runtime
-support.
+bookkeeping path. This baseline is CPU-only and diagnostic/reference only;
+it does not claim shipped GPU latent-heat parity or temperature-feedback
+runtime support.
 
 ### CondensationIsothermalStaggered (two-pass Gauss-Seidel)
 

--- a/docs/Features/condensation_strategy_system.md
+++ b/docs/Features/condensation_strategy_system.md
@@ -191,6 +191,16 @@ step mass-transfer quantity. For the current single-box public example path,
 that diagnostic aligns with the mass-concentration contract and should be
 reported as an energy density.
 
+For the current shipped support boundary, the executable baseline is the
+CPU integration test
+`particula/integration_tests/condensation_latent_heat_conservation_test.py`.
+It verifies a finite nonzero condensation transfer, particle water gain,
+gas water loss, total water conservation, and final-step
+`last_latent_heat_energy` agreement with the constant-latent-heat
+bookkeeping path. This baseline is CPU-only and diagnostic only; it does not
+claim completed GPU latent-heat parity or temperature-feedback runtime
+support.
+
 ### CondensationIsothermalStaggered (two-pass Gauss-Seidel)
 
 `CondensationIsothermalStaggered` splits each timestep into two passes. Theta
@@ -627,6 +637,7 @@ aerosol, gas = selective.step(
 - **Dynamics overview**: [Wall loss strategy system](./wall_loss_strategy_system.md)
 - **Examples**: [docs/Examples/Simulations/index.md](../Examples/Simulations/index.md)
 - **Latent-heat example**: [CPU latent-heat condensation bookkeeping](../Examples/Dynamics/Condensation/Condensation_Latent_Heat.ipynb)
+- **CPU integration baseline**: `particula/integration_tests/condensation_latent_heat_conservation_test.py`
 - **Theory**: [docs/Theory/index.md](../Theory/index.md)
 
 ## FAQ

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,8 @@ Whether you’re a researcher, educator, or industry expert, Particula is design
   latent-heat energy-density bookkeeping, and the
   `CondensationLatentHeat` strategy with latent-heat-corrected
   `mass_transfer_rate()`/`rate()` plus a `step()` that tracks per-step
-  latent heat diagnostics without claiming temperature-feedback runtime
+  latent heat diagnostics. The shipped support boundary is CPU-only and
+  does not claim GPU latent-heat parity or temperature-feedback runtime
   support.
 - **Interrogating your experimental data** to validate and expand your impact.
 - **Fostering open-source collaboration** to share ideas and build on each other’s work.

--- a/particula/integration_tests/condensation_latent_heat_conservation_test.py
+++ b/particula/integration_tests/condensation_latent_heat_conservation_test.py
@@ -7,6 +7,10 @@ deterministic, supersaturated, single-species water aerosol.
 import numpy as np
 import particula as par
 
+LATENT_HEAT_WATER = 2.26e6  # J/kg
+CONSERVATION_RTOL = 1e-12
+CONSERVATION_ATOL = 1e-18
+
 
 def _as_float(value: float | np.ndarray) -> float:
     """Convert a scalar-like value to ``float`` for deterministic assertions.
@@ -18,6 +22,20 @@ def _as_float(value: float | np.ndarray) -> float:
         The first value from ``value`` as a Python float.
     """
     return float(np.asarray(value, dtype=np.float64).reshape(-1)[0])
+
+
+def _particle_water_inventory(aerosol: par.Aerosol) -> float:
+    """Return the total particle-phase water inventory for the fixture.
+
+    Args:
+        aerosol: Single-species aerosol state under test.
+
+    Returns:
+        Total particle-phase water inventory as a scalar in kg/m^3.
+    """
+    species_mass = aerosol.particles.get_species_mass()
+    concentration = aerosol.particles.get_concentration()
+    return float(np.sum(species_mass[:, 0] * concentration, dtype=np.float64))
 
 
 def _build_test_aerosol() -> tuple[par.Aerosol, float]:
@@ -86,7 +104,7 @@ def _build_condensation() -> tuple[
     latent_heat_strategy = par.gas.LatentHeatFactory().get_strategy(
         "constant",
         {
-            "latent_heat_ref": 2.26e6,
+            "latent_heat_ref": LATENT_HEAT_WATER,
             "latent_heat_ref_units": "J/kg",
         },
     )
@@ -126,43 +144,66 @@ def test_condensation_latent_heat_fixture_executes_via_mass_condensation() -> (
     """Verify MassCondensation transfers water through the CPU path.
 
     The test confirms that the public latent-heat runnable produces a finite,
-    nonzero gas-to-particle transfer and positive latent-heat bookkeeping over
-    a short fixed loop.
+    nonzero gas-to-particle transfer, conserves total water inventory, and
+    records the final-step latent-heat bookkeeping over a short fixed loop.
     """
     aerosol, _ = _build_test_aerosol()
     condensation, condensation_strategy = _build_condensation()
 
-    initial_gas_concentration = _as_float(
+    initial_particle_water = _particle_water_inventory(aerosol)
+    initial_gas_water = _as_float(
         aerosol.atmosphere.partitioning_species.get_concentration()
     )
-    initial_particle_mass_concentration = _as_float(
-        aerosol.particles.get_mass_concentration()
-    )
+    initial_total_water = initial_particle_water + initial_gas_water
 
     current = aerosol
-    for _ in range(5):
+    for _ in range(4):
         current = condensation.execute(current, time_step=0.1, sub_steps=1)
 
-    final_gas_concentration = _as_float(
+    pre_final_particle_water = _particle_water_inventory(current)
+    pre_final_gas_water = _as_float(
         current.atmosphere.partitioning_species.get_concentration()
     )
-    final_particle_mass_concentration = _as_float(
-        current.particles.get_mass_concentration()
-    )
+    current = condensation.execute(current, time_step=0.1, sub_steps=1)
 
-    assert np.isfinite(initial_gas_concentration)
-    assert np.isfinite(final_gas_concentration)
-    assert np.isfinite(initial_particle_mass_concentration)
-    assert np.isfinite(final_particle_mass_concentration)
+    final_particle_water = _particle_water_inventory(current)
+    final_gas_water = _as_float(
+        current.atmosphere.partitioning_species.get_concentration()
+    )
+    final_total_water = final_particle_water + final_gas_water
+    final_step_particle_gain = final_particle_water - pre_final_particle_water
+    final_step_gas_loss = pre_final_gas_water - final_gas_water
+    expected_final_step_energy = final_step_particle_gain * LATENT_HEAT_WATER
+
+    assert np.isfinite(initial_particle_water)
+    assert np.isfinite(initial_gas_water)
+    assert np.isfinite(pre_final_particle_water)
+    assert np.isfinite(pre_final_gas_water)
+    assert np.isfinite(final_particle_water)
+    assert np.isfinite(final_gas_water)
     assert np.isfinite(condensation_strategy.last_latent_heat_energy)
     assert condensation_strategy.last_latent_heat_energy > 0.0
 
-    assert (
-        final_particle_mass_concentration > initial_particle_mass_concentration
+    assert final_particle_water > initial_particle_water
+    assert final_gas_water < initial_gas_water
+
+    np.testing.assert_allclose(
+        initial_total_water,
+        final_total_water,
+        rtol=CONSERVATION_RTOL,
+        atol=CONSERVATION_ATOL,
     )
-    assert final_gas_concentration < initial_gas_concentration
-    assert (
-        final_particle_mass_concentration - initial_particle_mass_concentration
-        > 0.0
+
+    assert final_step_particle_gain > 0.0
+    np.testing.assert_allclose(
+        final_step_particle_gain,
+        final_step_gas_loss,
+        rtol=CONSERVATION_RTOL,
+        atol=CONSERVATION_ATOL,
     )
-    assert initial_gas_concentration - final_gas_concentration > 0.0
+    np.testing.assert_allclose(
+        condensation_strategy.last_latent_heat_energy,
+        expected_final_step_energy,
+        rtol=CONSERVATION_RTOL,
+        atol=CONSERVATION_ATOL,
+    )

--- a/particula/integration_tests/condensation_latent_heat_conservation_test.py
+++ b/particula/integration_tests/condensation_latent_heat_conservation_test.py
@@ -6,6 +6,7 @@ deterministic, supersaturated, single-species water aerosol.
 
 import numpy as np
 import particula as par
+import pytest
 
 LATENT_HEAT_WATER = 2.26e6  # J/kg
 CONSERVATION_RTOL = 1e-12
@@ -16,12 +17,22 @@ def _as_float(value: float | np.ndarray) -> float:
     """Convert a scalar-like value to ``float`` for deterministic assertions.
 
     Args:
-        value: Scalar or array-like value to collapse to a Python float.
+        value: Scalar or size-1 array-like value to convert to a Python float.
 
     Returns:
-        The first value from ``value`` as a Python float.
+        The scalar value from ``value`` as a Python float.
+
+    Raises:
+        AssertionError: If ``value`` has more than one element.
     """
-    return float(np.asarray(value, dtype=np.float64).reshape(-1)[0])
+    array_value = np.asarray(value, dtype=np.float64)
+    if array_value.ndim == 0:
+        return float(array_value)
+    if array_value.size != 1:
+        raise AssertionError(
+            f"Expected scalar or size-1 input, got shape {array_value.shape}."
+        )
+    return float(array_value.reshape(()))
 
 
 def _particle_water_inventory(aerosol: par.Aerosol) -> float:
@@ -32,10 +43,27 @@ def _particle_water_inventory(aerosol: par.Aerosol) -> float:
 
     Returns:
         Total particle-phase water inventory as a scalar in kg/m^3.
+
+    Raises:
+        AssertionError: If the particle mass layout is not a valid
+            single-species shape.
     """
-    species_mass = aerosol.particles.get_species_mass()
+    species_mass = np.asarray(
+        aerosol.particles.get_species_mass(), dtype=np.float64
+    )
     concentration = aerosol.particles.get_concentration()
-    return float(np.sum(species_mass[:, 0] * concentration, dtype=np.float64))
+
+    if species_mass.ndim == 1:
+        water_mass = species_mass
+    elif species_mass.ndim == 2 and species_mass.shape[1] == 1:
+        water_mass = species_mass[:, 0]
+    else:
+        raise AssertionError(
+            "Expected single-species particle mass with shape "
+            f"(n_particles,) or (n_particles, 1), got {species_mass.shape}."
+        )
+
+    return float(np.sum(water_mass * concentration, dtype=np.float64))
 
 
 def _build_test_aerosol() -> tuple[par.Aerosol, float]:
@@ -136,6 +164,68 @@ def test_condensation_latent_heat_fixture_starts_supersaturated() -> None:
     assert np.isfinite(saturation_concentration)
     assert np.isfinite(gas_concentration)
     assert gas_concentration > saturation_concentration
+
+
+def test_as_float_rejects_multi_element_inputs() -> None:
+    """Regression: helper rejects multi-element fixture/API drift."""
+    with pytest.raises(AssertionError, match="Expected scalar or size-1 input"):
+        _as_float(np.array([1.0, 2.0], dtype=np.float64))
+
+
+@pytest.mark.parametrize(
+    "mass_shape",
+    [
+        (4,),
+        (4, 1),
+    ],
+)
+def test_particle_water_inventory_accepts_valid_single_species_shapes(
+    mass_shape: tuple[int, ...],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: helper accepts valid single-species mass layouts."""
+    aerosol, _ = _build_test_aerosol()
+    species_mass = np.asarray(
+        aerosol.particles.get_species_mass(), dtype=np.float64
+    )
+    reshaped_mass = species_mass.reshape(mass_shape)
+    monkeypatch.setattr(
+        aerosol.particles,
+        "get_species_mass",
+        lambda: reshaped_mass,
+    )
+
+    expected = float(
+        np.sum(
+            species_mass.reshape(-1) * aerosol.particles.get_concentration(),
+            dtype=np.float64,
+        )
+    )
+
+    np.testing.assert_allclose(_particle_water_inventory(aerosol), expected)
+
+
+def test_particle_water_inventory_rejects_multi_species_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: helper fails loudly for unexpected multi-species mass."""
+    aerosol, _ = _build_test_aerosol()
+    species_mass = np.asarray(
+        aerosol.particles.get_species_mass(), dtype=np.float64
+    )
+    monkeypatch.setattr(
+        aerosol.particles,
+        "get_species_mass",
+        lambda: np.column_stack(
+            [species_mass.reshape(-1), species_mass.reshape(-1)]
+        ),
+    )
+
+    with pytest.raises(
+        AssertionError,
+        match="Expected single-species particle mass",
+    ):
+        _particle_water_inventory(aerosol)
 
 
 def test_condensation_latent_heat_fixture_executes_via_mass_condensation() -> (

--- a/particula/integration_tests/condensation_latent_heat_conservation_test.py
+++ b/particula/integration_tests/condensation_latent_heat_conservation_test.py
@@ -126,7 +126,8 @@ def test_condensation_latent_heat_fixture_executes_via_mass_condensation() -> (
     """Verify MassCondensation transfers water through the CPU path.
 
     The test confirms that the public latent-heat runnable produces a finite,
-    nonzero gas-to-particle transfer over a short fixed loop.
+    nonzero gas-to-particle transfer and positive latent-heat bookkeeping over
+    a short fixed loop.
     """
     aerosol, _ = _build_test_aerosol()
     condensation, condensation_strategy = _build_condensation()
@@ -154,6 +155,7 @@ def test_condensation_latent_heat_fixture_executes_via_mass_condensation() -> (
     assert np.isfinite(initial_particle_mass_concentration)
     assert np.isfinite(final_particle_mass_concentration)
     assert np.isfinite(condensation_strategy.last_latent_heat_energy)
+    assert condensation_strategy.last_latent_heat_energy > 0.0
 
     assert (
         final_particle_mass_concentration > initial_particle_mass_concentration

--- a/particula/integration_tests/condensation_latent_heat_conservation_test.py
+++ b/particula/integration_tests/condensation_latent_heat_conservation_test.py
@@ -1,16 +1,32 @@
-"""Integration baseline for CPU latent-heat condensation."""
+"""Integration baseline for CPU latent-heat condensation.
+
+This module exercises the public ``particula as par`` runnable path for a
+deterministic, supersaturated, single-species water aerosol.
+"""
 
 import numpy as np
 import particula as par
 
 
 def _as_float(value: float | np.ndarray) -> float:
-    """Convert scalar-like values to float for deterministic assertions."""
+    """Convert a scalar-like value to ``float`` for deterministic assertions.
+
+    Args:
+        value: Scalar or array-like value to collapse to a Python float.
+
+    Returns:
+        The first value from ``value`` as a Python float.
+    """
     return float(np.asarray(value, dtype=np.float64).reshape(-1)[0])
 
 
 def _build_test_aerosol() -> tuple[par.Aerosol, float]:
-    """Build a supersaturated single-species water aerosol state."""
+    """Build a supersaturated single-species water aerosol state.
+
+    Returns:
+        A tuple containing the configured aerosol and the corresponding water
+        saturation concentration in kg/m^3.
+    """
     molar_mass_water = 18.015e-3  # kg/mol
     temperature = 298.15  # K
     vapor_pressure_water = par.gas.VaporPressureFactory().get_strategy(
@@ -61,7 +77,12 @@ def _build_condensation() -> tuple[
     par.dynamics.MassCondensation,
     par.dynamics.CondensationLatentHeat,
 ]:
-    """Build the public latent-heat condensation runnable and strategy."""
+    """Build the public latent-heat condensation runnable and strategy.
+
+    Returns:
+        A tuple containing the public ``MassCondensation`` runnable and its
+        ``CondensationLatentHeat`` strategy.
+    """
     latent_heat_strategy = par.gas.LatentHeatFactory().get_strategy(
         "constant",
         {
@@ -83,7 +104,11 @@ def _build_condensation() -> tuple[
 
 
 def test_condensation_latent_heat_fixture_starts_supersaturated() -> None:
-    """The CPU fixture starts above saturation to avoid a no-op baseline."""
+    """Verify the CPU fixture starts above saturation.
+
+    The precondition prevents this integration baseline from silently becoming
+    a no-op transfer case.
+    """
     aerosol, saturation_concentration = _build_test_aerosol()
 
     gas_concentration = _as_float(
@@ -98,7 +123,11 @@ def test_condensation_latent_heat_fixture_starts_supersaturated() -> None:
 def test_condensation_latent_heat_fixture_executes_via_mass_condensation() -> (
     None
 ):
-    """MassCondensation transfers water through the CPU latent-heat path."""
+    """Verify MassCondensation transfers water through the CPU path.
+
+    The test confirms that the public latent-heat runnable produces a finite,
+    nonzero gas-to-particle transfer over a short fixed loop.
+    """
     aerosol, _ = _build_test_aerosol()
     condensation, condensation_strategy = _build_condensation()
 

--- a/particula/integration_tests/condensation_latent_heat_conservation_test.py
+++ b/particula/integration_tests/condensation_latent_heat_conservation_test.py
@@ -1,0 +1,137 @@
+"""Integration baseline for CPU latent-heat condensation."""
+
+import numpy as np
+import particula as par
+
+
+def _as_float(value: float | np.ndarray) -> float:
+    """Convert scalar-like values to float for deterministic assertions."""
+    return float(np.asarray(value, dtype=np.float64).reshape(-1)[0])
+
+
+def _build_test_aerosol() -> tuple[par.Aerosol, float]:
+    """Build a supersaturated single-species water aerosol state."""
+    molar_mass_water = 18.015e-3  # kg/mol
+    temperature = 298.15  # K
+    vapor_pressure_water = par.gas.VaporPressureFactory().get_strategy(
+        "water_buck"
+    )
+    saturation_concentration = vapor_pressure_water.saturation_concentration(
+        molar_mass=molar_mass_water,
+        temperature=temperature,
+    )
+    gas_species = (
+        par.gas.GasSpeciesBuilder()
+        .set_molar_mass(molar_mass_water, "kg/mol")
+        .set_vapor_pressure_strategy(vapor_pressure_water)
+        .set_concentration(saturation_concentration * 1.03, "kg/m^3")
+        .set_name("H2O")
+        .set_partitioning(True)
+        .build()
+    )
+    atmosphere = (
+        par.gas.AtmosphereBuilder()
+        .set_more_partitioning_species(gas_species)
+        .set_temperature(temperature, "K")
+        .set_pressure(101325.0, "Pa")
+        .build()
+    )
+
+    particle_radii = np.array([30e-9, 45e-9, 60e-9, 90e-9], dtype=np.float64)
+    density = 1000.0  # kg/m^3
+    particle_mass = (4.0 / 3.0) * np.pi * particle_radii**3 * density
+    particles = (
+        par.particles.ResolvedParticleMassRepresentationBuilder()
+        .set_distribution_strategy(
+            par.particles.ParticleResolvedSpeciatedMass()
+        )
+        .set_activity_strategy(par.particles.ActivityIdealMass())
+        .set_surface_strategy(par.particles.SurfaceStrategyVolume())
+        .set_mass(particle_mass.reshape(-1, 1), "kg")
+        .set_density(np.array([density], dtype=np.float64), "kg/m^3")
+        .set_charge(np.zeros_like(particle_radii, dtype=np.float64))
+        .set_volume(1.0e-6, "m^3")
+        .build()
+    )
+    aerosol = par.Aerosol(atmosphere=atmosphere, particles=particles)
+    return aerosol, float(saturation_concentration)
+
+
+def _build_condensation() -> tuple[
+    par.dynamics.MassCondensation,
+    par.dynamics.CondensationLatentHeat,
+]:
+    """Build the public latent-heat condensation runnable and strategy."""
+    latent_heat_strategy = par.gas.LatentHeatFactory().get_strategy(
+        "constant",
+        {
+            "latent_heat_ref": 2.26e6,
+            "latent_heat_ref_units": "J/kg",
+        },
+    )
+    condensation_strategy = par.dynamics.CondensationLatentHeat(
+        molar_mass=np.array([18.015e-3], dtype=np.float64),
+        diffusion_coefficient=2e-5,
+        accommodation_coefficient=1.0,
+        latent_heat_strategy=latent_heat_strategy,
+        update_gases=True,
+    )
+    condensation = par.dynamics.MassCondensation(
+        condensation_strategy=condensation_strategy
+    )
+    return condensation, condensation_strategy
+
+
+def test_condensation_latent_heat_fixture_starts_supersaturated() -> None:
+    """The CPU fixture starts above saturation to avoid a no-op baseline."""
+    aerosol, saturation_concentration = _build_test_aerosol()
+
+    gas_concentration = _as_float(
+        aerosol.atmosphere.partitioning_species.get_concentration()
+    )
+
+    assert np.isfinite(saturation_concentration)
+    assert np.isfinite(gas_concentration)
+    assert gas_concentration > saturation_concentration
+
+
+def test_condensation_latent_heat_fixture_executes_via_mass_condensation() -> (
+    None
+):
+    """MassCondensation transfers water through the CPU latent-heat path."""
+    aerosol, _ = _build_test_aerosol()
+    condensation, condensation_strategy = _build_condensation()
+
+    initial_gas_concentration = _as_float(
+        aerosol.atmosphere.partitioning_species.get_concentration()
+    )
+    initial_particle_mass_concentration = _as_float(
+        aerosol.particles.get_mass_concentration()
+    )
+
+    current = aerosol
+    for _ in range(5):
+        current = condensation.execute(current, time_step=0.1, sub_steps=1)
+
+    final_gas_concentration = _as_float(
+        current.atmosphere.partitioning_species.get_concentration()
+    )
+    final_particle_mass_concentration = _as_float(
+        current.particles.get_mass_concentration()
+    )
+
+    assert np.isfinite(initial_gas_concentration)
+    assert np.isfinite(final_gas_concentration)
+    assert np.isfinite(initial_particle_mass_concentration)
+    assert np.isfinite(final_particle_mass_concentration)
+    assert np.isfinite(condensation_strategy.last_latent_heat_energy)
+
+    assert (
+        final_particle_mass_concentration > initial_particle_mass_concentration
+    )
+    assert final_gas_concentration < initial_gas_concentration
+    assert (
+        final_particle_mass_concentration - initial_particle_mass_concentration
+        > 0.0
+    )
+    assert initial_gas_concentration - final_gas_concentration > 0.0

--- a/particula/tests/condensation_latent_heat_docs_test.py
+++ b/particula/tests/condensation_latent_heat_docs_test.py
@@ -14,9 +14,13 @@ CONDENSATION_FEATURE_PATH = (
     ROOT / "docs/Features/condensation_strategy_system.md"
 )
 DOCS_INDEX_PATH = ROOT / "docs/index.md"
+ROADMAP_PATH = ROOT / "docs/Features/Roadmap/data-oriented-gpu.md"
 PUBLISHED_NOTEBOOK_RELATIVE_PATH = "Condensation/Condensation_Latent_Heat.ipynb"
 FEATURE_NOTEBOOK_RELATIVE_PATH = (
     "../Examples/Dynamics/Condensation/Condensation_Latent_Heat.ipynb"
+)
+CPU_BASELINE_TEST_PATH = (
+    "particula/integration_tests/condensation_latent_heat_conservation_test.py"
 )
 INDEX_NOTEBOOK_LABEL = (
     "[Condensation: Latent Heat Bookkeeping]"
@@ -26,11 +30,23 @@ INDEX_REVIEWED_DESCRIPTION_SNIPPET = (
     "Published CPU-only latent-heat bookkeeping walkthrough"
 )
 INDEX_BOOKKEEPING_CONTRACT_SNIPPET = "diagnostic only and does not feed back"
+INDEX_CPU_BASELINE_SNIPPET = "The executable CPU integration baseline remains"
 DOCS_INDEX_LATENT_HEAT_HEADING = (
     "**Supporting CPU latent-heat-corrected condensation diagnostics**"
 )
 DOCS_INDEX_LATENT_HEAT_CONTRACT_SNIPPET = (
-    "without claiming temperature-feedback runtime"
+    "does not claim GPU latent-heat parity or temperature-feedback runtime"
+)
+FEATURE_CPU_BASELINE_SNIPPET = (
+    "This baseline is CPU-only and diagnostic/reference only"
+)
+FEATURE_FUTURE_WORK_SNIPPET = (
+    "temperature-feedback runtime support and GPU latent-heat parity remain"
+)
+ROADMAP_CPU_BASELINE_SNIPPET = "current executable CPU integration baseline"
+ROADMAP_FUTURE_WORK_SNIPPETS = (
+    "Temperature-feedback runtime support",
+    "latent-heat parity remain future Epic D goals",
 )
 
 
@@ -73,6 +89,8 @@ def test_dynamics_index_links_published_latent_heat_notebook() -> None:
     assert INDEX_NOTEBOOK_LABEL in content
     assert INDEX_REVIEWED_DESCRIPTION_SNIPPET in content
     assert INDEX_BOOKKEEPING_CONTRACT_SNIPPET in content
+    assert INDEX_CPU_BASELINE_SNIPPET in content
+    assert CPU_BASELINE_TEST_PATH in content
 
 
 def test_dynamics_index_drops_raw_latent_heat_python_command() -> None:
@@ -100,7 +118,27 @@ def test_docs_index_latent_heat_summary_stays_diagnostic_only() -> None:
     content = DOCS_INDEX_PATH.read_text(encoding="utf-8")
 
     assert DOCS_INDEX_LATENT_HEAT_HEADING in content
-    assert "temperature-feedback runtime" in content
-    assert "support." in content
     assert DOCS_INDEX_LATENT_HEAT_CONTRACT_SNIPPET in content
     assert "**Supporting non-isothermal condensation**" not in content
+
+
+def test_condensation_feature_page_keeps_cpu_only_latent_heat_boundary() -> (
+    None
+):
+    """Feature page keeps the reviewed CPU-only latent-heat contract."""
+    content = CONDENSATION_FEATURE_PATH.read_text(encoding="utf-8")
+
+    assert CPU_BASELINE_TEST_PATH in content
+    assert FEATURE_CPU_BASELINE_SNIPPET in content
+    assert FEATURE_FUTURE_WORK_SNIPPET in content
+
+
+def test_roadmap_latent_heat_note_stays_future_facing() -> None:
+    """Roadmap page keeps GPU latent-heat support as future work."""
+    content = ROADMAP_PATH.read_text(encoding="utf-8")
+
+    assert ROADMAP_CPU_BASELINE_SNIPPET in content
+    assert CPU_BASELINE_TEST_PATH in content
+    for snippet in ROADMAP_FUTURE_WORK_SNIPPETS:
+        assert snippet in content
+    assert "with per-box temperature feedback through the" not in content


### PR DESCRIPTION
**Target Branch:** `main`

Closes #1267
Closes #1268
Closes #1269

## Summary

Adds a deterministic CPU integration-level reference for latent-heat condensation, providing the conservation and bookkeeping baseline needed before future Epic D GPU parity work. The feature exercises only public `particula` APIs and explicitly keeps GPU latent-heat parity and temperature-feedback runtime support out of scope.

## What Changed

### Integration Baseline

- `particula/integration_tests/condensation_latent_heat_conservation_test.py` - Adds a supersaturated, single-species water fixture that executes the public `MassCondensation` CPU path with a constant latent-heat strategy.
- Validates gas-to-particle transfer, whole-run water conservation, final-step particle/gas mass closure, and latent-heat energy bookkeeping.
- Adds defensive regression checks for scalar conversion and supported single-species particle-mass layouts.

### Documentation and Validation

- `docs/Features/Roadmap/data-oriented-gpu.md` - Identifies the executable CPU baseline for future GPU work while preserving future-facing parity language.
- `docs/Features/condensation_strategy_system.md` - Documents the CPU-only diagnostic/reference boundary.
- `docs/Examples/Dynamics/index.md`, `docs/index.md`, and `AGENTS.md` - Link and summarize the baseline in contributor and user guidance.
- `particula/tests/condensation_latent_heat_docs_test.py` - Verifies documentation continues to distinguish the shipped CPU baseline from unimplemented GPU parity and temperature feedback.
- `.opencode/plans/features/E3-F7.json` and associated plan sections - Record all three E3-F7 phases as shipped.

## How It Works

The deterministic fixture starts with supersaturated water vapor and particle-resolved droplets, then advances condensation through the public runnable:

```
Supersaturated gas + particle water
                 │
                 ▼
      MassCondensation.execute()
                 │
        ┌────────┴────────┐
        ▼                 ▼
 particle mass gain   gas mass loss
        │                 │
        └────────┬────────┘
                 ▼
 water conservation + latent-heat energy closure
```

The test records initial, pre-final, and final inventories. It checks total water conservation across the run, confirms final-step particle gain equals gas loss, and verifies `last_latent_heat_energy` equals transferred water mass multiplied by the explicit `2.26e6 J/kg` latent-heat constant.

## Implementation Notes

- **Why this approach**: A deterministic public-API integration fixture gives future CPU/GPU comparisons a reviewed reference without changing production behavior.
- **Numerical contract**: Conservation uses `rtol=1e-12` and `atol=1e-18` with explicit `float64` fixture data.
- **Scope boundary**: This PR does not claim GPU latent-heat parity or add temperature-feedback runtime behavior.

## Testing

Coverage includes:

- Initial supersaturation and nonzero condensation transfer.
- Whole-run particle-plus-gas water conservation.
- Final-step particle gain, gas loss, and latent-heat energy closure.
- Fixture helper shape and scalar-conversion regressions.
- Documentation wording and links for the CPU-only baseline.

Focused validation commands:

```bash
pytest particula/integration_tests/condensation_latent_heat_conservation_test.py -q -Werror
pytest particula/tests/condensation_latent_heat_docs_test.py -q -Werror
pytest particula/integration_tests -q
```