### PR TITLE
feat: add manifest cleanup and complete Epic C roadmap

### DIFF
--- a/.opencode/plans/epics/E3.json
+++ b/.opencode/plans/epics/E3.json
@@ -2,7 +2,7 @@
   "id": "E3",
   "type": "epic",
   "title": "Epic C: GPU Kernel Correctness and Low-Level API Hardening",
-  "status": "Draft",
+  "status": "Shipped",
   "priority": "P2",
   "size": "M",
   "owners": [
@@ -10,8 +10,8 @@
   ],
   "start_date": "2026-07-08",
   "target_date": null,
-  "completion_date": null,
-  "last_updated": "2026-07-08",
+  "completion_date": "2026-07-12",
+  "last_updated": "2026-07-12",
   "dependencies": [],
   "section_files": {
     "appendix": ".opencode/plans/sections/epics/E3/appendix.md",
@@ -33,5 +33,5 @@
   "milestones": [],
   "governance_log": [],
   "risk_register": [],
-  "lifecycle": "active"
+  "lifecycle": "completed"
 }

--- a/.opencode/plans/features/E3-F2.json
+++ b/.opencode/plans/features/E3-F2.json
@@ -2,7 +2,7 @@
   "id": "E3-F2",
   "type": "feature",
   "title": "Harden or characterize coagulation rejection sampling for mixed NPF/droplet ranges",
-  "status": "Draft",
+  "status": "Shipped",
   "priority": "P2",
   "size": "M",
   "owners": [
@@ -10,8 +10,8 @@
   ],
   "start_date": "2026-07-08",
   "target_date": null,
-  "completion_date": null,
-  "last_updated": "2026-07-09",
+  "completion_date": "2026-07-12",
+  "last_updated": "2026-07-12",
   "dependencies": [],
   "section_files": {
     "architecture_design": ".opencode/plans/sections/features/E3-F2/architecture_design.md",
@@ -34,11 +34,11 @@
     {
       "id": "E3-F2-P1",
       "title": "Add mixed NPF/droplet fixture and acceptance-rate diagnostics with unit tests",
-      "status": "Not Started",
+      "status": "Shipped",
       "size": "S",
       "issue_number": null,
       "start_date": null,
-      "completion_date": null,
+      "completion_date": "2026-07-12",
       "estimates": null,
       "actuals": null,
       "notes_ref": null,
@@ -47,11 +47,11 @@
     {
       "id": "E3-F2-P2",
       "title": "Prototype bounded mixed-scale sampling hardening with conservation tests",
-      "status": "Not Started",
+      "status": "Shipped",
       "size": "S",
       "issue_number": null,
       "start_date": null,
-      "completion_date": null,
+      "completion_date": "2026-07-12",
       "estimates": null,
       "actuals": null,
       "notes_ref": null,
@@ -85,5 +85,5 @@
     }
   ],
   "totals": null,
-  "lifecycle": "active"
+  "lifecycle": "completed"
 }

--- a/.opencode/tools/__tests__/auto_mode_manifest.test.ts
+++ b/.opencode/tools/__tests__/auto_mode_manifest.test.ts
@@ -237,6 +237,84 @@ describe("auto_mode_manifest wrapper", () => {
     ]);
   });
 
+  it("routes delete and prune with bounded non-interactive options", async () => {
+    const execute = await loadToolExecute("../../auto_mode_manifest.ts");
+
+    const deleteResult = await execute({
+      command: "delete",
+      branch: "epic/e14-auto",
+      options: "dry-run",
+    });
+    const pruneResult = await execute({
+      command: "prune",
+      completed: true,
+      options: "force",
+    });
+
+    expect(deleteResult).toBe("ok");
+    expect(pruneResult).toBe("ok");
+    expect(getInvocations()[0]?.args).toEqual([
+      "uv",
+      "run",
+      "--active",
+      "adw",
+      "auto-mode",
+      "delete",
+      "--branch",
+      "epic/e14-auto",
+      "--dry-run",
+    ]);
+    expect(getInvocations()[1]?.args).toEqual([
+      "uv",
+      "run",
+      "--active",
+      "adw",
+      "auto-mode",
+      "prune",
+      "--completed",
+      "--force",
+    ]);
+  });
+
+  it("routes delete --force and prune --dry-run symmetrically", async () => {
+    const execute = await loadToolExecute("../../auto_mode_manifest.ts");
+
+    const deleteResult = await execute({
+      command: "delete",
+      branch: "epic/e14-auto",
+      options: "force",
+    });
+    const pruneResult = await execute({
+      command: "prune",
+      completed: true,
+      options: "dry-run",
+    });
+
+    expect(deleteResult).toBe("ok");
+    expect(pruneResult).toBe("ok");
+    expect(getInvocations()[0]?.args).toEqual([
+      "uv",
+      "run",
+      "--active",
+      "adw",
+      "auto-mode",
+      "delete",
+      "--branch",
+      "epic/e14-auto",
+      "--force",
+    ]);
+    expect(getInvocations()[1]?.args).toEqual([
+      "uv",
+      "run",
+      "--active",
+      "adw",
+      "auto-mode",
+      "prune",
+      "--completed",
+      "--dry-run",
+    ]);
+  });
+
   it("documents workflow-context requirements for manual completion", async () => {
     await loadToolExecute("../../auto_mode_manifest.ts");
 
@@ -323,6 +401,54 @@ describe("auto_mode_manifest wrapper", () => {
     expect(getInvocations()).toHaveLength(0);
   });
 
+  it("rejects delete and prune when required selectors are missing or invalid before spawn", async () => {
+    const execute = await loadToolExecute("../../auto_mode_manifest.ts");
+
+    expect(String(await execute({ command: "delete", options: "force" }))).toContain(
+      "'branch' is required for delete",
+    );
+    expect(
+      String(await execute({ command: "delete", branch: "--bad", options: "force" })),
+    ).toContain("Invalid branch name");
+    expect(String(await execute({ command: "prune", options: "force" }))).toContain(
+      "'completed: true' is required for prune",
+    );
+    expect(
+      String(await execute({ command: "prune", completed: false, options: "dry-run" })),
+    ).toContain("'completed: true' is required for prune");
+    expect(getInvocations()).toHaveLength(0);
+  });
+
+  it("rejects interactive delete and prune invocations without dry-run or force", async () => {
+    const execute = await loadToolExecute("../../auto_mode_manifest.ts");
+
+    const deleteResult = await execute({ command: "delete", branch: "feature/a" });
+    const pruneResult = await execute({ command: "prune", completed: true });
+
+    expect(String(deleteResult)).toContain("Interactive 'delete' calls are not allowed via wrapper");
+    expect(String(pruneResult)).toContain("Interactive 'prune' calls are not allowed via wrapper");
+    expect(getInvocations()).toHaveLength(0);
+  });
+
+  it("rejects command-disallowed tokens for delete and prune before spawn", async () => {
+    const execute = await loadToolExecute("../../auto_mode_manifest.ts");
+
+    const deleteResult = await execute({
+      command: "delete",
+      branch: "feature/a",
+      options: "resume",
+    });
+    const pruneResult = await execute({
+      command: "prune",
+      completed: true,
+      options: "json",
+    });
+
+    expect(String(deleteResult)).toContain("token is not allowed for command 'delete'");
+    expect(String(pruneResult)).toContain("token is not allowed for command 'prune'");
+    expect(getInvocations()).toHaveLength(0);
+  });
+
   it("rejects invalid options tokens before spawn", async () => {
     const execute = await loadToolExecute("../../auto_mode_manifest.ts");
 
@@ -362,6 +488,21 @@ describe("auto_mode_manifest wrapper", () => {
 
     expect(String(statusResult)).toContain("ERROR: Invalid branch name: --json");
     expect(String(initResult)).toContain("ERROR: Invalid branch name: --force");
+    expect(getInvocations()).toHaveLength(0);
+  });
+
+  it("rejects whitespace-only branch values before spawn", async () => {
+    const execute = await loadToolExecute("../../auto_mode_manifest.ts");
+
+    const deleteResult = await execute({
+      command: "delete",
+      branch: "   ",
+      options: "force",
+    });
+    const statusResult = await execute({ command: "status", branch: "\t" });
+
+    expect(String(deleteResult)).toContain("Branch name cannot be blank or whitespace-only");
+    expect(String(statusResult)).toContain("Branch name cannot be blank or whitespace-only");
     expect(getInvocations()).toHaveLength(0);
   });
 

--- a/.opencode/tools/__tests__/find_files.test.ts
+++ b/.opencode/tools/__tests__/find_files.test.ts
@@ -187,7 +187,7 @@ describe("find_files wrapper", () => {
 
     try {
       const result = await execute({ pattern: "**/*.ts", options: "max-results=2 compact-output" });
-      expect(String(result)).toBe(`.opencode/tools/__tests__/fixtures/search_scope/newest.ts\n.opencode/tools/__tests__/fixtures/search_scope/middle.ts\n\n${
+      expect(String(result)).toBe(`tools/__tests__/fixtures/search_scope/newest.ts\ntools/__tests__/fixtures/search_scope/middle.ts\n\n${
         '[WARNING: Results truncated to 2 files (3 total found). Use options: "max-results=<n>" to increase limit.]'
       }`);
     } finally {

--- a/.opencode/tools/__tests__/wrapper_schema_inventory.test.ts
+++ b/.opencode/tools/__tests__/wrapper_schema_inventory.test.ts
@@ -120,7 +120,7 @@ describe("wrapper schema inventory", () => {
     expect(row.status).toBe("ok");
     expect(row.exempt_fields).toContain("options");
     expect(row.counted_fields).not.toContain("options");
-    expect(row.current_count).toBe(13);
+    expect(row.current_count).toBe(14);
     expect(row.classification).toBe("split-needed");
   });
 

--- a/.opencode/tools/auto_mode_manifest.md
+++ b/.opencode/tools/auto_mode_manifest.md
@@ -10,14 +10,16 @@ Structured wrapper for auto-mode manifest operations.
 | `init` | `issues` | Build a manifest from explicit issue numbers |
 | `status` | — | Show manifest state |
 | `validate` | — | Validate manifest state |
+| `delete` | `branch` | Remove one manifest registry entry by exact source branch |
+| `prune` | `completed=true` | Remove all registry entries whose top-level status is `completed` |
 | `reset` | `issue` | Reset one issue's manifest state |
 | `complete` | `issue`, `adw_id` | Mark one issue completed for accumulate-mode handoff |
 
 ## Preferred Usage
 
-This is the active wrapper for auto-mode manifest operations. Optional toggles
-now use bounded command-scoped `options` tokens, while payload-bearing fields
-stay direct.
+This is the active compatibility wrapper for auto-mode manifest operations until
+the narrower split replacement path ships. Optional toggles now use bounded
+command-scoped `options` tokens, while payload-bearing fields stay direct.
 
 ## Examples
 
@@ -34,6 +36,12 @@ stay direct.
 // Validate a branch-scoped manifest
 { "command": "validate", "branch": "feature/F42" }
 
+// Preview deleting exactly one manifest registry entry
+{ "command": "delete", "branch": "feature/F42", "options": "dry-run" }
+
+// Force-prune all manifests whose top-level status is completed
+{ "command": "prune", "completed": true, "options": "force" }
+
 // Reset an issue and resume downstream work
 { "command": "reset", "issue": "42", "branch": "feature/F42", "options": "resume force" }
 
@@ -49,6 +57,8 @@ stay direct.
 | `init` | `force` |
 | `status` | `json` |
 | `validate` | none |
+| `delete` | `dry-run`, `force` |
+| `prune` | `dry-run`, `force` |
 | `reset` | `resume`, `force` |
 | `complete` | `force`, `dry-run`, `branch-merged`, `no-branch-merged` |
 
@@ -66,6 +76,7 @@ Keep these fields direct:
 - `segment_size`
 - `ship_strategy`
 - `branch`
+- `completed`
 - `completed_at`
 - `detail`
 
@@ -73,6 +84,18 @@ Keep these fields direct:
 
 - Use bare tokens such as `options: "force"`, `options: "json"`, or
   `options: "resume force"`.
+- Wrapper-routed `delete` and `prune` calls must stay non-interactive: include
+  `options: "dry-run"`, `options: "force"`, or both. Calls that omit both are
+  rejected before spawn so agents never hang on a confirmation prompt.
+- Wrapper-routed `branch` inputs for `status`, `validate`, `delete`, `reset`,
+  and `complete` must be non-blank after trimming; whitespace-only values are
+  rejected before spawn.
+- `delete` and `prune` remove manifest registry entries only. They do **not**
+  delete Git branches, remotes, or worktrees; mutate platform issue state; or
+  touch per-workflow ADW state.
+- `prune` selects only manifests whose top-level `status == "completed"`.
+  This is intentionally different from cron-owned cleanup lifecycle pruning,
+  which also considers retained `cleanup_status` state.
 - Cleanup lifecycle note for accumulate mode:
   - `status` and `cleanup_status` are different surfaces. `status=completed`
     means issue accumulation is done; retained cleanup visibility lives in

--- a/.opencode/tools/auto_mode_manifest.ts
+++ b/.opencode/tools/auto_mode_manifest.ts
@@ -16,7 +16,16 @@ function normalizeAdwId(value: unknown): string | null {
   return trimmed.toLowerCase();
 }
 
-const COMMANDS = ["init-from-batch", "init", "status", "validate", "reset", "complete"] as const;
+const COMMANDS = [
+  "init-from-batch",
+  "init",
+  "status",
+  "validate",
+  "delete",
+  "prune",
+  "reset",
+  "complete",
+] as const;
 const MAX_ISSUES = 500;
 const MAX_DEPENDS = 500;
 const MAX_BRANCH_LEN = 255;
@@ -29,6 +38,8 @@ const COMMAND_OPTION_TOKENS = {
   init: ["force"],
   status: ["json"],
   validate: [],
+  delete: ["dry-run", "force"],
+  prune: ["dry-run", "force"],
   reset: ["resume", "force"],
   complete: ["force", "dry-run", "branch-merged", "no-branch-merged"],
 } as const satisfies Record<AutoModeCommand, readonly string[]>;
@@ -38,6 +49,8 @@ const USAGE_EXAMPLE = `Example usage:
   auto_mode_manifest({ command: "init", issues: "42,43", depends: "43:42", ship_strategy: "pr", options: "force" })
   auto_mode_manifest({ command: "status", branch: "epic/e14-auto", options: "json" })
   auto_mode_manifest({ command: "validate", branch: "epic/e14-auto" })
+  auto_mode_manifest({ command: "delete", branch: "epic/e14-auto", options: "dry-run" })
+  auto_mode_manifest({ command: "prune", completed: true, options: "force" })
   auto_mode_manifest({ command: "reset", issue: "42", branch: "epic/e14-auto", options: "resume force" })
   auto_mode_manifest({ command: "complete", issue: "42", adw_id: "abc12345", branch: "epic/e14-auto", completed_at: "2026-06-27T23:59:59Z", detail: "Issue completed (branch accumulation).", options: "branch-merged dry-run" })`;
 
@@ -53,6 +66,14 @@ const COMMAND_DESCRIPTIONS = `AVAILABLE COMMANDS:
 
 • validate: Validate current manifest state
   Usage: { command: "validate", branch?: "epic/e14-auto" }
+
+• delete: Remove one manifest registry entry by exact branch
+  Usage: { command: "delete", branch: "epic/e14-auto", options: "dry-run" }
+  Note: one of options: "dry-run" or options: "force" is required.
+
+• prune: Remove all completed manifest registry entries
+  Usage: { command: "prune", completed: true, options: "force" }
+  Note: one of options: "dry-run" or options: "force" is required.
 
 • reset: Reset manifest issue state
   Usage: { command: "reset", issue: "42", branch?: "epic/e14-auto", options?: "resume force" }
@@ -133,7 +154,10 @@ function validateBranchRef(branchName: string): string | null {
   return null;
 }
 
-function normalizeBranchInput(value: string | undefined): {
+function normalizeBranchInput(
+  value: string | undefined,
+  options?: { rejectBlankProvided?: boolean },
+): {
   normalized: string | null;
   error?: string;
 } {
@@ -142,6 +166,9 @@ function normalizeBranchInput(value: string | undefined): {
   }
   const trimmed = value.trim();
   if (!trimmed) {
+    if (options?.rejectBlankProvided) {
+      return { normalized: null, error: "Branch name cannot be blank or whitespace-only." };
+    }
     return { normalized: null };
   }
   const error = validateBranchRef(trimmed);
@@ -351,7 +378,7 @@ function appendBranchMetadata(
 }
 
 function appendBranchFilter(cmdParts: (string | number)[], branch?: string): string | null {
-  const normalizedBranch = normalizeBranchInput(branch);
+  const normalizedBranch = normalizeBranchInput(branch, { rejectBlankProvided: true });
   if (normalizedBranch.error) {
     return normalizedBranch.error;
   }
@@ -537,6 +564,64 @@ function buildResetCommand(
   return null;
 }
 
+function requireNonInteractiveMutationOptions(
+  command: "delete" | "prune",
+  options: ParsedCommandOptions,
+): string | null {
+  if (options["dry-run"] || options.force) {
+    return null;
+  }
+  return `Interactive '${command}' calls are not allowed via wrapper; include options: \"dry-run\" or options: \"force\".`;
+}
+
+function buildDeleteCommand(
+  cmdParts: (string | number)[],
+  args: AutoModeManifestArgs,
+  options: ParsedCommandOptions,
+): string | null {
+  const interactionError = requireNonInteractiveMutationOptions("delete", options);
+  if (interactionError) {
+    return interactionError;
+  }
+  if (!args.branch) {
+    return "'branch' is required for delete.";
+  }
+  cmdParts.push("delete");
+  const branchError = appendBranchFilter(cmdParts, args.branch);
+  if (branchError) {
+    return branchError;
+  }
+  if (options["dry-run"]) {
+    cmdParts.push("--dry-run");
+  }
+  if (options.force) {
+    cmdParts.push("--force");
+  }
+  return null;
+}
+
+function buildPruneCommand(
+  cmdParts: (string | number)[],
+  args: AutoModeManifestArgs,
+  options: ParsedCommandOptions,
+): string | null {
+  const interactionError = requireNonInteractiveMutationOptions("prune", options);
+  if (interactionError) {
+    return interactionError;
+  }
+  if (args.completed !== true) {
+    return "'completed: true' is required for prune.";
+  }
+  cmdParts.push("prune", "--completed");
+  if (options["dry-run"]) {
+    cmdParts.push("--dry-run");
+  }
+  if (options.force) {
+    cmdParts.push("--force");
+  }
+  return null;
+}
+
 function buildCompleteCommand(
   cmdParts: (string | number)[],
   args: AutoModeManifestArgs,
@@ -592,6 +677,8 @@ export default tool({
 
 This tool wraps the auto-mode CLI commands with validation to provide agents
 safe access to manifest creation, inspection, resets, and manual completion.
+It remains the active compatibility wrapper for this surface; keep using this
+wrapper until the split replacement path is shipped.
 
 ${COMMAND_DESCRIPTIONS}
 
@@ -616,6 +703,8 @@ REQUIRED PARAMETERS BY COMMAND:
 • init: issues
 • status: none
 • validate: none
+• delete: branch, options with one of dry-run/force
+• prune: completed=true, options with one of dry-run/force
 • reset: issue
 • complete: issue, adw_id`),
 
@@ -665,6 +754,8 @@ SUPPORTED TOKENS:
 • init: force
 • status: json
 • reset: resume, force
+• delete: dry-run, force (one required)
+• prune: dry-run, force (one required)
 • complete: force, dry-run, branch-merged, no-branch-merged
 
 Use space-separated bare tokens and keep payload-bearing fields explicit.
@@ -724,8 +815,17 @@ ALLOWED: pr, accumulate`),
       .optional()
       .describe(`Branch name filter for manifest operations.
 
-APPLIES TO: status, validate, reset, complete
+APPLIES TO: status, validate, delete, reset, complete
+Whitespace-only values are rejected.
 MAPS TO: --branch`),
+
+    completed: tool.schema
+      .boolean()
+      .optional()
+      .describe(`Completed-manifest selector.
+
+REQUIRED FOR: prune
+Set to true to map to --completed. False or omitted values are rejected.`),
 
     completed_at: tool.schema
       .string()
@@ -779,6 +879,16 @@ MAPS TO: --detail`),
 
       case "validate": {
         buildErrorMessage = buildValidateCommand(cmdParts, args);
+        break;
+      }
+
+      case "delete": {
+        buildErrorMessage = buildDeleteCommand(cmdParts, args, optionValues);
+        break;
+      }
+
+      case "prune": {
+        buildErrorMessage = buildPruneCommand(cmdParts, args, optionValues);
         break;
       }
 
@@ -839,6 +949,7 @@ interface AutoModeManifestArgs {
   ship_strategy?: string;
   issue?: string;
   branch?: string;
+  completed?: boolean;
   completed_at?: string;
   detail?: string;
 }

--- a/.opencode/tools/wrapper_schema_inventory.json
+++ b/.opencode/tools/wrapper_schema_inventory.json
@@ -406,13 +406,14 @@
         "ship_strategy",
         "issue",
         "branch",
+        "completed",
         "completed_at",
         "detail"
       ],
       "exempt_fields": [
         "options"
       ],
-      "current_count": 13,
+      "current_count": 14,
       "diagnostic": null,
       "classification": "split-needed",
       "target_shape": "split-wrapper-family",

--- a/docs/Features/Roadmap/data-oriented-gpu.md
+++ b/docs/Features/Roadmap/data-oriented-gpu.md
@@ -21,8 +21,8 @@ documentation conventions.
 | --- | --- | --- | --- |
 | 1 | [Epic A: Data-Model and Numerical Foundations](#epic-a-data-model-and-numerical-foundations) | Shipped | E2 |
 | 2 | [Epic B: Non-Isothermal Condensation Public API (CPU)](#epic-b-non-isothermal-condensation-public-api-cpu) | Shipped | E1 |
-| 3 | [Epic C: GPU Kernel Correctness and Low-Level API Hardening](#epic-c-gpu-kernel-correctness-and-low-level-api-hardening) | Next up | not scheduled |
-| 4 | [Epic D: GPU Condensation Physics Parity](#epic-d-gpu-condensation-physics-parity) | Pending | not scheduled |
+| 3 | [Epic C: GPU Kernel Correctness and Low-Level API Hardening](#epic-c-gpu-kernel-correctness-and-low-level-api-hardening) | Shipped | E3 |
+| 4 | [Epic D: GPU Condensation Physics Parity](#epic-d-gpu-condensation-physics-parity) | Next up | not scheduled |
 | 5 | [Epic E: GPU Coagulation Physics Coverage](#epic-e-gpu-coagulation-physics-coverage) | Pending | not scheduled |
 | 6 | [Epic F: GPU Process Completeness](#epic-f-gpu-process-completeness) | Pending | not scheduled |
 | 7 | [Epic G: Backend Selection and GPU-Resident Simulation](#epic-g-backend-selection-and-gpu-resident-simulation) | Pending | not scheduled |
@@ -696,10 +696,12 @@ Shipped scope (tracked in plan E1):
   parity (fixed-shape state, explicit environment inputs, no hidden CPU↔GPU
   movement).
 
-Two follow-ups were deferred out of E1: the runnable latent-heat example
-(E3-F6) and the integration-level conservation case (E3-F7). They are
-scheduled as features 8 and 9 in
-[Epic C](#epic-c-gpu-kernel-correctness-and-low-level-api-hardening).
+Two follow-ups were deferred out of E1 and subsequently shipped in Epic C/E3:
+the runnable
+[CPU latent-heat example](../../Examples/Dynamics/Condensation/Condensation_Latent_Heat.ipynb)
+(E3-F6) and the integration-level conservation case in
+`particula/integration_tests/condensation_latent_heat_conservation_test.py`
+(E3-F7). Together they provide the executable CPU reference handed to Epic D.
 
 **Exit bar (met):** Latent-heat condensation is a documented, builder/factory
 accessible CPU workflow with validation coverage, and its API decisions are
@@ -707,11 +709,12 @@ recorded as the reference contract for GPU latent-heat parity in Epic D.
 
 ## Epic C: GPU Kernel Correctness and Low-Level API Hardening
 
-Make the existing low-level GPU kernels correct, reproducible, and usable
-from documentation alone before adding new physics. This epic absorbs the
-former "documented low-level GPU API" milestone, the cross-cutting
-validation-infrastructure work, and the two documentation/validation
-follow-ups deferred from Epic B (plan E1).
+Status: shipped as ADW plan E3 on 2026-07-12. All seven child feature tracks
+and their phases are marked shipped. The implementation made the existing
+low-level GPU kernels reproducible and usable from documentation alone before
+new physics is added. This epic absorbed the former "documented low-level GPU
+API" milestone, the cross-cutting validation-infrastructure work, and the two
+documentation/validation follow-ups deferred from Epic B (plan E1).
 
 For the current shipped baseline on explicit CPU↔GPU transfer helpers,
 `EnvironmentData` ownership, current CPU/GPU support boundaries, and the
@@ -722,7 +725,7 @@ guide and the
 epic and every later epic extend those contracts rather than redefining
 them.
 
-Planned features:
+Shipped scope:
 
 1. Persist coagulation RNG state: seed once at loop setup and keep per-box
    RNG state between `coagulation_step_gpu` calls instead of re-launching the
@@ -804,24 +807,25 @@ Planned features:
       `pytest particula/gpu/tests/cuda_availability_test.py -q` for the shared
       skip contract and `pytest particula/gpu/kernels/tests/environment_test.py
       -q -m "warp and cuda"` for optional CUDA-if-available coverage
-8. Add a runnable `docs/Examples/` entry for a `CondensationLatentHeat`
-   workflow (deferred from E1; current tutorials only set `latent_heat` as a
-   vapor property), following the paired `.py`/`.ipynb` example conventions.
-9. Add a `particula/integration_tests/` latent-heat conservation case
-   (deferred from E1; today the conservation and energy regressions are
-   unit-level only), establishing the CPU integration baseline that the
-   Epic D latent-heat parity tests will reuse.
+8. The paired
+   [`CondensationLatentHeat` example](../../Examples/Dynamics/Condensation/Condensation_Latent_Heat.ipynb)
+   now provides a runnable CPU-only bookkeeping workflow (E3-F6), completing
+   the documentation follow-up deferred from E1.
+9. `particula/integration_tests/condensation_latent_heat_conservation_test.py`
+   now establishes the CPU mass-conservation and latent-heat bookkeeping
+   baseline that Epic D parity tests can reuse (E3-F7).
 
-**Exit bar:** A new user can run both kernels from the docs on a CUDA device
-and on Warp CPU without reading source, repeated coagulation steps draw
+**Exit bar (met):** A new user can run both kernels from the docs on a CUDA
+device and on Warp CPU without reading source, repeated coagulation steps draw
 uncorrelated samples from a caller-initialized persistent RNG buffer, the
 device-aware test policy plus parity tolerances are recorded, and the deferred
 E1 latent-heat example and integration-conservation case have landed.
 
 ### Known Kernel Issues
 
-Concrete defects and design limits in the existing kernels that should be
-fixed or explicitly accepted during this epic.
+Concrete defects and design limits reviewed during Epic C. The RNG defect was
+fixed; the mixed-scale global-majorant and one-thread-per-box limits were
+explicitly accepted with evidence and remain bounded follow-up concerns.
 
 - **RNG state ownership.** `coagulation_step_gpu` seeds once and reuses a
   caller-owned per-box RNG buffer across timesteps. Repeated calls should keep
@@ -910,11 +914,21 @@ fixed or explicitly accepted during this epic.
   or link checker is claimed here.
 - **One-thread-per-box coagulation.** The kernel launches one GPU thread per
   box with sequential pair selection inside the thread. This matches the
-  multi-box scaling priority but serializes large single-box workloads. Record
-  this as a deliberate design decision with its measured single-box limit, or
-  plan a parallel-within-box variant.
+  multi-box scaling priority but serializes large single-box workloads. Epic C
+  accepted this as the current measured baseline with the single-box caution
+  band in the
+  [decision record](#measured-decision-record-for-the-current-one-thread-per-box-path).
+  A parallel-within-box variant requires a separate evidence-backed proposal.
 
 ## Epic D: GPU Condensation Physics Parity
+
+Status: next up; not yet scheduled as an ADW plan. Epic C has no unfinished
+exit-bar deliverables to roll forward. Epic D inherits the supported
+`particula.gpu.kernels` entry points, explicit transfer boundary, and
+device-aware validation policy from E3, plus the E3-F7 CPU latent-heat
+integration baseline. The accepted mixed-scale coagulation and
+parallel-within-box limitations are not condensation parity work; they remain
+documented constraints for Epic E or a separate evidence-backed proposal.
 
 Bring GPU condensation to parity with the CPU reference paths from Epics A
 and B: latent-heat physics, on-device thermodynamics, and the activity and

--- a/docs/Features/Roadmap/index.md
+++ b/docs/Features/Roadmap/index.md
@@ -85,17 +85,27 @@ meets its exit bar, the next pending epic in the sequence becomes active.
 - [Epic B: Non-Isothermal Condensation Public API (CPU)](data-oriented-gpu.md#epic-b-non-isothermal-condensation-public-api-cpu)
   (ADW plan E1) — public builder/factory access, validation, and
   documentation for latent-heat condensation on the CPU reference path.
+- [Epic C: GPU Kernel Correctness and Low-Level API Hardening](data-oriented-gpu.md#epic-c-gpu-kernel-correctness-and-low-level-api-hardening)
+  (ADW plan E3) — persistent coagulation RNG state, bounded mixed-scale
+  selector hardening, measured one-thread-per-box limits, documented direct
+  kernel entry points, device-aware test policy, and the completed Epic B
+  latent-heat example and integration baseline. Shipped artifacts:
+    - [Direct GPU kernels quick-start](../../Examples/gpu_direct_kernels_quick_start.py)
+      — explicit transfer and low-level condensation/coagulation kernel path
+    - [CPU latent-heat condensation example](../../Examples/Dynamics/Condensation/Condensation_Latent_Heat.ipynb)
+      — runnable bookkeeping reference for future GPU parity
+    - [Measured coagulation decision record](data-oriented-gpu.md#measured-decision-record-for-the-current-one-thread-per-box-path)
+      — accepted many-box baseline and large single-box caution band
 
 ### Next Up
 
-- [Epic C: GPU Kernel Correctness and Low-Level API Hardening](data-oriented-gpu.md#epic-c-gpu-kernel-correctness-and-low-level-api-hardening)
+- [Epic D: GPU Condensation Physics Parity](data-oriented-gpu.md#epic-d-gpu-condensation-physics-parity)
   — the next epic in the sequence; not yet scheduled as an ADW plan.
 
 ### Pending
 
 Listed in execution order; each becomes active when the previous epic ships.
 
-- [Epic D: GPU Condensation Physics Parity](data-oriented-gpu.md#epic-d-gpu-condensation-physics-parity)
 - [Epic E: GPU Coagulation Physics Coverage](data-oriented-gpu.md#epic-e-gpu-coagulation-physics-coverage)
 - [Epic F: GPU Process Completeness](data-oriented-gpu.md#epic-f-gpu-process-completeness)
 - [Epic G: Backend Selection and GPU-Resident Simulation](data-oriented-gpu.md#epic-g-backend-selection-and-gpu-resident-simulation)


### PR DESCRIPTION
**Target Branch:** `main`

## Summary
- add bounded, non-interactive `delete` and `prune` operations to the auto-mode manifest wrapper
- add validation and wrapper tests for cleanup selectors, options, and branch inputs
- mark the E3 GPU kernel-hardening plan shipped and update the roadmap to hand off to Epic D

## Testing
- Not run as part of PR creation